### PR TITLE
Add conferencing support

### DIFF
--- a/docs/conferencing.md
+++ b/docs/conferencing.md
@@ -1,0 +1,52 @@
+# VoIP Conferencing
+
+This is a draft proposal for a naive voice/video conferencing implementation for
+Matrix clients.  There are many possible conferencing architectures possible for
+Matrix (Multipoint Conferencing Unit (MCU); Stream Forwarding Unit (SFU); Peer-
+to-Peer mesh (P2P), etc; events shared in the group room; events shared 1:1;
+possibly even out-of-band signalling).
+
+This is a starting point for a naive MCU implementation which could provide one
+possible Matrix-wide solution in  future, which retains backwards compatibility
+with standard 1:1 calling.
+
+ * A client chooses to initiate a conference for a given room by starting a
+   voice or video call with a 'conference focus' user.  This is a virtual user
+   (typically Application Service) which implements a conferencing bridge.  It
+   isn't defined how the client discovers or selects this user.
+
+ * The conference focus user MUST join the room in which the client has
+   initiated the conference - this may require the client to invite the
+   conference focus user to the room, depending on the room's `join_rules`. The
+   conference focus user needs to be in the room to let the bridge eject users
+   from the conference who have left the room in which it was initiated, and aid
+   discovery of the conference by other users in the room.  The bridge
+   identifies the room to join based on the user ID by which it was invited.
+   The format of this identifier is implementation dependent for now.
+
+ * If a client leaves the group chat room, they MUST be ejected from the
+   conference. If a client leaves the 1:1 room with the conference focus user,
+   they SHOULD be ejected from the conference.
+
+ * For now, rooms can contain multiple conference focus users - it's left to
+   user or client implementation to select which to converge on.  In future this
+   could be mediated using a state event (e.g. `im.vector.call.mcu`), but we
+   can't do that right now as by default normal users can't set arbitrary state
+   events on a room.
+
+ * To participate in the conference, other clients initiates a standard 1:1
+   voice or video call to the conference focus user.
+
+ * For best UX, clients SHOULD show the ongoing voice/video call in the UI
+   context of the group room rather than 1:1 with the focus user.  If a client
+   recognises a conference user present in the room, it MAY chose to highlight
+   this in the UI (e.g. with a "conference ongoing" notification, to aid
+   discovery).  Clients MAY hide the 1:1 room with the focus user (although in
+   future this room could be used for floor control or other direct
+   communication with the conference focus)
+
+ * When all users have left the conference, the 'conference focus' user SHOULD
+   leave the room.
+
+ * If a conference focus user joins a room but does not receive a 1:1 voice or
+   video call, it SHOULD time out after a period of time and leave the room.

--- a/skins/base/css/organisms/RoomView.css
+++ b/skins/base/css/organisms/RoomView.css
@@ -218,3 +218,12 @@ limitations under the License.
     background-color: blue;
     height: 5px;
 }
+
+.mx_RoomView_ongoingConfCallNotification {
+    width: 100%;
+    text-align: center;
+    background-color: #ff0064;
+    color: #fff;
+    font-weight: bold;
+    padding: 6px;
+}

--- a/skins/base/css/templates/Login.css
+++ b/skins/base/css/templates/Login.css
@@ -75,6 +75,22 @@ limitations under the License.
     opacity: 0.8;
 }
 
+.mx_Login_create:link {
+    color: #4a4a4a;
+}
+
+.mx_Login_links {
+    display: block;
+    text-align: center;
+    width: 100%;
+    font-size: 14px;
+    opacity: 0.8;
+}
+
+.mx_Login_links a:link {
+   color: #4a4a4a;
+}
+
 .mx_Login_loader {
     position: absolute;
     left: 50%;
@@ -85,12 +101,10 @@ limitations under the License.
     color: #ff2020;
     font-weight: bold;
     text-align: center;
+/*
     height: 24px;
+*/
     margin-top: 12px;
     margin-bottom: 12px;
-}
-
-.mx_Login_create:link {
-    color: #4a4a4a;
 }
 

--- a/skins/base/views/organisms/RoomList.js
+++ b/skins/base/views/organisms/RoomList.js
@@ -18,7 +18,7 @@ limitations under the License.
 
 var React = require('react');
 var ComponentBroker = require('../../../../src/ComponentBroker');
-
+var CallView = ComponentBroker.get('molecules/voip/CallView');
 var RoomDropTarget = ComponentBroker.get('molecules/RoomDropTarget');
 
 var RoomListController = require("../../../../src/controllers/organisms/RoomList");
@@ -28,8 +28,14 @@ module.exports = React.createClass({
     mixins: [RoomListController],
 
     render: function() {
+        var callElement;
+        if (this.state.show_call_element) {
+            callElement = <CallView className="mx_MatrixChat_callView"/>
+        }
+
         return (
             <div className="mx_RoomList">
+                {callElement}
                 <h2 className="mx_RoomList_favourites_label">Favourites</h2>
                 <RoomDropTarget text="Drop here to favourite"/>
 

--- a/skins/base/views/organisms/RoomView.js
+++ b/skins/base/views/organisms/RoomView.js
@@ -179,7 +179,7 @@ module.exports = React.createClass({
             var conferenceCallNotification = null;
             if (this.state.displayConfCallNotification) {
                 conferenceCallNotification = (
-                    <div className="mx_RoomView_ongoingConfCallNotification">
+                    <div className="mx_RoomView_ongoingConfCallNotification" onClick={this.onConferenceNotificationClick}>
                         Ongoing conference call
                     </div>
                 );

--- a/skins/base/views/organisms/RoomView.js
+++ b/skins/base/views/organisms/RoomView.js
@@ -176,6 +176,15 @@ module.exports = React.createClass({
                 roomEdit = <Loader/>;
             }
 
+            var conferenceCallNotification = null;
+            if (this.state.displayConfCallNotification) {
+                conferenceCallNotification = (
+                    <div className="mx_RoomView_ongoingConfCallNotification">
+                        Ongoing conference call
+                    </div>
+                );
+            }
+
             var fileDropTarget = null;
             if (this.state.draggingFile) {
                 fileDropTarget = <div className="mx_RoomView_fileDropTarget">
@@ -192,6 +201,7 @@ module.exports = React.createClass({
                         onSettingsClick={this.onSettingsClick} onSaveClick={this.onSaveClick} onCancelClick={this.onCancelClick} />
                     <div className="mx_RoomView_auxPanel">
                         <CallView room={this.state.room}/>
+                        { conferenceCallNotification }
                         { roomEdit }
                     </div>
                     <div ref="messageWrapper" className="mx_RoomView_messagePanel" onScroll={ this.onMessageListScroll }>

--- a/skins/base/views/pages/MatrixChat.js
+++ b/skins/base/views/pages/MatrixChat.js
@@ -89,6 +89,7 @@ module.exports = React.createClass({
                 call_element = <CallView className="mx_MatrixChat_callView"/>
             }
 
+            // TODO: Fix duplication here and do conditionals like we do above
             if (Notifier.supportsDesktopNotifications() && !Notifier.isEnabled() && !Notifier.isToolbarHidden()) {
                 return (
                         <div className="mx_MatrixChat_wrapper">

--- a/skins/base/views/pages/MatrixChat.js
+++ b/skins/base/views/pages/MatrixChat.js
@@ -18,7 +18,6 @@ limitations under the License.
 
 var React = require('react');
 var ComponentBroker = require('../../../../src/ComponentBroker');
-var CallHandler = require('../../../../src/CallHandler');
 
 var LeftPanel = ComponentBroker.get('organisms/LeftPanel');
 var RoomView = ComponentBroker.get('organisms/RoomView');
@@ -30,7 +29,6 @@ var CreateRoom = ComponentBroker.get('organisms/CreateRoom');
 var RoomDirectory = ComponentBroker.get('organisms/RoomDirectory');
 var MatrixToolbar = ComponentBroker.get('molecules/MatrixToolbar');
 var Notifier = ComponentBroker.get('organisms/Notifier');
-var CallView = ComponentBroker.get('molecules/voip/CallView');
 
 var MatrixChatController = require('../../../../src/controllers/pages/MatrixChat');
 
@@ -55,7 +53,7 @@ module.exports = React.createClass({
     render: function() {
         if (this.state.logged_in && this.state.ready) {
 
-            var page_element, call_element;
+            var page_element;
             var right_panel = "";
 
             switch (this.state.page_type) {
@@ -76,18 +74,6 @@ module.exports = React.createClass({
                     right_panel = <RightPanel/>
                     break;
             }
-            // if we aren't viewing a room with an ongoing call, but there is an
-            // active call, show the call element - we need to do this to make
-            // audio/video not crap out
-            if (this.state.active_call && (
-                    !this.state.currentRoom ||
-                    !CallHandler.getCallForRoom(this.state.currentRoom))) {
-                console.log(
-                    "Creating global CallView for active call in room %s",
-                    this.state.active_call.roomId
-                );
-                call_element = <CallView className="mx_MatrixChat_callView"/>
-            }
 
             // TODO: Fix duplication here and do conditionals like we do above
             if (Notifier.supportsDesktopNotifications() && !Notifier.isEnabled() && !Notifier.isToolbarHidden()) {
@@ -96,7 +82,6 @@ module.exports = React.createClass({
                             <MatrixToolbar />
                             <div className="mx_MatrixChat mx_MatrixChat_toolbarShowing">
                                 <LeftPanel selectedRoom={this.state.currentRoom} />
-                                {call_element}
                                 <main className="mx_MatrixChat_middlePanel">
                                     {page_element}
                                 </main>
@@ -109,7 +94,6 @@ module.exports = React.createClass({
                 return (
                         <div className="mx_MatrixChat">
                             <LeftPanel selectedRoom={this.state.currentRoom} />
-                            {call_element}
                             <main className="mx_MatrixChat_middlePanel">
                                 {page_element}
                             </main>

--- a/skins/base/views/pages/MatrixChat.js
+++ b/skins/base/views/pages/MatrixChat.js
@@ -80,7 +80,8 @@ module.exports = React.createClass({
             // active call, show the call element - we need to do this to make
             // audio/video not crap out
             if (this.state.active_call && (
-                    !this.state.currentRoom || !CallHandler.getCall(this.state.currentRoom))) {
+                    !this.state.currentRoom ||
+                    !CallHandler.getCallForRoom(this.state.currentRoom))) {
                 console.log(
                     "Creating global CallView for active call in room %s",
                     this.state.active_call.roomId

--- a/skins/base/views/pages/MatrixChat.js
+++ b/skins/base/views/pages/MatrixChat.js
@@ -18,6 +18,7 @@ limitations under the License.
 
 var React = require('react');
 var ComponentBroker = require('../../../../src/ComponentBroker');
+var CallHandler = require('../../../../src/CallHandler');
 
 var LeftPanel = ComponentBroker.get('organisms/LeftPanel');
 var RoomView = ComponentBroker.get('organisms/RoomView');
@@ -29,8 +30,9 @@ var CreateRoom = ComponentBroker.get('organisms/CreateRoom');
 var RoomDirectory = ComponentBroker.get('organisms/RoomDirectory');
 var MatrixToolbar = ComponentBroker.get('molecules/MatrixToolbar');
 var Notifier = ComponentBroker.get('organisms/Notifier');
+var CallView = ComponentBroker.get('molecules/voip/CallView');
 
-var MatrixChatController = require("../../../../src/controllers/pages/MatrixChat");
+var MatrixChatController = require('../../../../src/controllers/pages/MatrixChat');
 
 // should be atomised
 var Loader = require("react-loader");
@@ -53,7 +55,7 @@ module.exports = React.createClass({
     render: function() {
         if (this.state.logged_in && this.state.ready) {
 
-            var page_element;
+            var page_element, call_element;
             var right_panel = "";
 
             switch (this.state.page_type) {
@@ -74,6 +76,17 @@ module.exports = React.createClass({
                     right_panel = <RightPanel/>
                     break;
             }
+            // if we aren't viewing a room with an ongoing call, but there is an
+            // active call, show the call element - we need to do this to make
+            // audio/video not crap out
+            if (this.state.active_call && (
+                    !this.state.currentRoom || !CallHandler.getCall(this.state.currentRoom))) {
+                console.log(
+                    "Creating global CallView for active call in room %s",
+                    this.state.active_call.roomId
+                );
+                call_element = <CallView className="mx_MatrixChat_callView"/>
+            }
 
             if (Notifier.supportsDesktopNotifications() && !Notifier.isEnabled() && !Notifier.isToolbarHidden()) {
                 return (
@@ -81,6 +94,7 @@ module.exports = React.createClass({
                             <MatrixToolbar />
                             <div className="mx_MatrixChat mx_MatrixChat_toolbarShowing">
                                 <LeftPanel selectedRoom={this.state.currentRoom} />
+                                {call_element}
                                 <main className="mx_MatrixChat_middlePanel">
                                     {page_element}
                                 </main>
@@ -93,6 +107,7 @@ module.exports = React.createClass({
                 return (
                         <div className="mx_MatrixChat">
                             <LeftPanel selectedRoom={this.state.currentRoom} />
+                            {call_element}
                             <main className="mx_MatrixChat_middlePanel">
                                 {page_element}
                             </main>

--- a/skins/base/views/templates/Login.js
+++ b/skins/base/views/templates/Login.js
@@ -165,6 +165,13 @@ module.exports = React.createClass({
                         {this.state.errorText}
                 </div>
                 <a className="mx_Login_create" onClick={this.showRegister} href="#">Create a new account</a>
+                <br/>
+                <div className="mx_Login_links">
+                    <a href="https://medium.com/@Vector">blog</a>&nbsp;&nbsp;&middot;&nbsp;&nbsp;
+                    <a href="https://twitter.com/@VectorCo">twitter</a>&nbsp;&nbsp;&middot;&nbsp;&nbsp;
+                    <a href="https://github.com/vector-im/vector-web">github</a>&nbsp;&nbsp;&middot;&nbsp;&nbsp;
+                    <a href="https://matrix.org">powered by Matrix</a>
+                </div>
             </div>
         );
     },

--- a/src/CallHandler.js
+++ b/src/CallHandler.js
@@ -57,7 +57,7 @@ var MatrixClientPeg = require("./MatrixClientPeg");
 var Modal = require("./Modal");
 var ComponentBroker = require('./ComponentBroker');
 var ErrorDialog = ComponentBroker.get("organisms/ErrorDialog");
-var ConferenceHandler = require("./ConferenceHandler");
+var ConferenceCall = require("./ConferenceHandler").ConferenceCall;
 var Matrix = require("matrix-js-sdk");
 var dis = require("./dispatcher");
 
@@ -196,10 +196,10 @@ dis.register(function(payload) {
             }
             else { // > 2
                 console.log("Place conference call in %s", payload.room_id);
-                var confHandler = new ConferenceHandler(
+                var confCall = new ConferenceCall(
                     MatrixClientPeg.get(), payload.room_id
                 );
-                confHandler.setup().done(function(call) {
+                confCall.setup().done(function(call) {
                     placeCall(call);
                 }, function(err) {
                     console.error("Failed to setup conference call: %s", err);

--- a/src/CallHandler.js
+++ b/src/CallHandler.js
@@ -58,6 +58,7 @@ var Modal = require("./Modal");
 var ComponentBroker = require('./ComponentBroker');
 var ErrorDialog = ComponentBroker.get("organisms/ErrorDialog");
 var ConferenceCall = require("./ConferenceHandler").ConferenceCall;
+var ConferenceHandler = require("./ConferenceHandler");
 var Matrix = require("matrix-js-sdk");
 var dis = require("./dispatcher");
 
@@ -241,8 +242,30 @@ dis.register(function(payload) {
 });
 
 module.exports = {
+
+    getCallForRoom: function(roomId) {
+        return (
+            module.exports.getCall(roomId) ||
+            module.exports.getConferenceCall(roomId)
+        );
+    },
+
     getCall: function(roomId) {
         return calls[roomId] || null;
+    },
+
+    getConferenceCall: function(roomId) {
+        // search for a conference 1:1 call for this group chat room ID
+        var activeCall = module.exports.getAnyActiveCall();
+        if (activeCall && activeCall.confUserId) {
+            var thisRoomConfUserId = ConferenceHandler.getConferenceUserIdForRoom(
+                roomId
+            );
+            if (thisRoomConfUserId === activeCall.confUserId) {
+                return activeCall;
+            }
+        }
+        return null;
     },
 
     getAnyActiveCall: function() {

--- a/src/CallHandler.js
+++ b/src/CallHandler.js
@@ -106,7 +106,7 @@ function _setCallListeners(call) {
             play("ringbackAudio");
         }
         else if (newState === "ended" && oldState === "connected") {
-            _setCallState(call, call.roomId, "ended");
+            _setCallState(undefined, call.roomId, "ended");
             pause("ringbackAudio");
             play("callendAudio");
         }
@@ -239,5 +239,16 @@ dis.register(function(payload) {
 module.exports = {
     getCall: function(roomId) {
         return calls[roomId] || null;
+    },
+
+    getAnyActiveCall: function() {
+        var roomsWithCalls = Object.keys(calls);
+        for (var i = 0; i < roomsWithCalls.length; i++) {
+            if (calls[roomsWithCalls[i]] &&
+                    calls[roomsWithCalls[i]].call_state !== "ended") {
+                return calls[roomsWithCalls[i]];
+            }
+        }
+        return null;
     }
 };

--- a/src/CallHandler.js
+++ b/src/CallHandler.js
@@ -154,7 +154,11 @@ function _setCallState(call, roomId, status) {
 dis.register(function(payload) {
     switch (payload.action) {
         case 'place_call':
-            if (calls[payload.room_id]) {
+            if (module.exports.getAnyActiveCall()) {
+                Modal.createDialog(ErrorDialog, {
+                    title: "Existing Call",
+                    description: "You are already in a call."
+                });
                 return; // don't allow >1 call to be placed.
             }
             var room = MatrixClientPeg.get().getRoom(payload.room_id);
@@ -207,7 +211,7 @@ dis.register(function(payload) {
             }
             break;
         case 'incoming_call':
-            if (calls[payload.call.roomId]) {
+            if (module.exports.getAnyActiveCall()) {
                 payload.call.hangup("busy");
                 return; // don't allow >1 call to be received, hangup newer one.
             }

--- a/src/ConferenceHandler.js
+++ b/src/ConferenceHandler.js
@@ -30,15 +30,8 @@ ConferenceHandler.prototype._joinConferenceUser = function() {
     if (!groupRoom) {
         return q.reject("Bad group room ID");
     }
-    var members = groupRoom.getJoinedMembers();
-    var confUserExists = false;
-    for (var i = 0; i < members.length; i++) {
-        if (members[i].userId === this.confUserId) {
-            confUserExists = true;
-            break;
-        }
-    }
-    if (confUserExists) {
+    var member = groupRoom.getMember(this.confUserId);
+    if (member && member.membership === "join") {
         return q();
     }
     return this.client.invite(this.groupRoomId, this.confUserId);
@@ -49,7 +42,8 @@ ConferenceHandler.prototype._getConferenceUserRoom = function() {
     var rooms = this.client.getRooms();
     var confRoom = null;
     for (var i = 0; i < rooms.length; i++) {
-        if (rooms[i].hasMembershipState(this.confUserId, "join") &&
+        var confUser = rooms[i].getMember(this.confUserId);
+        if (confUser && confUser.membership === "join" &&
                 rooms[i].getJoinedMembers().length === 2) {
             confRoom = rooms[i];
             break;

--- a/src/ConferenceHandler.js
+++ b/src/ConferenceHandler.js
@@ -1,0 +1,70 @@
+"use strict";
+var q = require("q");
+var Matrix = require("matrix-js-sdk");
+var Room = Matrix.Room;
+
+var USER_PREFIX = "fs_";
+var DOMAIN = "matrix.org";
+
+function ConferenceHandler(matrixClient, groupChatRoomId) {
+    this.client = matrixClient;
+    this.groupRoomId = groupChatRoomId;
+    // abuse browserify's core node Buffer support (strip padding ='s)
+    this.base64RoomId = new Buffer(this.groupRoomId).toString("base64").replace(/=/g, "");
+    this.confUserId = "@" + USER_PREFIX + this.base64RoomId + ":" + DOMAIN;
+}
+
+ConferenceHandler.prototype.setup = function() {
+    var self = this;
+    return this._joinConferenceUser().then(function() {
+        return self._getConferenceUserRoom();
+    }).then(function(room) {
+        // return a call for *this* room to be placed.
+        return Matrix.createNewMatrixCall(self.client, room.roomId);
+    });
+};
+
+ConferenceHandler.prototype._joinConferenceUser = function() {
+    // Make sure the conference user is in the group chat room
+    var groupRoom = this.client.getRoom(this.groupRoomId);
+    if (!groupRoom) {
+        return q.reject("Bad group room ID");
+    }
+    var members = groupRoom.getJoinedMembers();
+    var confUserExists = false;
+    for (var i = 0; i < members.length; i++) {
+        if (members[i].userId === this.confUserId) {
+            confUserExists = true;
+            break;
+        }
+    }
+    if (confUserExists) {
+        return q();
+    }
+    return this.client.invite(this.groupRoomId, this.confUserId);
+};
+
+ConferenceHandler.prototype._getConferenceUserRoom = function() {
+    // Use an existing 1:1 with the conference user; else make one
+    var rooms = this.client.getRooms();
+    var confRoom = null;
+    for (var i = 0; i < rooms.length; i++) {
+        if (rooms[i].hasMembershipState(this.confUserId, "join") &&
+                rooms[i].getJoinedMembers().length === 2) {
+            confRoom = rooms[i];
+            break;
+        }
+    }
+    if (confRoom) {
+        return q(confRoom);
+    }
+    return this.client.createRoom({
+        preset: "private_chat",
+        invite: [this.confUserId]
+    }).then(function(res) {
+        return new Room(res.room_id);
+    });
+};
+
+module.exports = ConferenceHandler;
+

--- a/src/ConferenceHandler.js
+++ b/src/ConferenceHandler.js
@@ -3,6 +3,10 @@ var q = require("q");
 var Matrix = require("matrix-js-sdk");
 var Room = Matrix.Room;
 
+// FIXME: This currently forces Vector to try to hit the matrix.org AS for conferencing.
+// This is bad because it prevents people running their own ASes from being used.
+// This isn't permanent and will be customisable in the future: see the proposal
+// at docs/conferencing.md for more info.
 var USER_PREFIX = "fs_";
 var DOMAIN = "matrix.org";
 

--- a/src/ConferenceHandler.js
+++ b/src/ConferenceHandler.js
@@ -6,15 +6,15 @@ var Room = Matrix.Room;
 var USER_PREFIX = "fs_";
 var DOMAIN = "matrix.org";
 
-function ConferenceHandler(matrixClient, groupChatRoomId) {
+function ConferenceCall(matrixClient, groupChatRoomId) {
     this.client = matrixClient;
     this.groupRoomId = groupChatRoomId;
     // abuse browserify's core node Buffer support (strip padding ='s)
-    this.base64RoomId = new Buffer(this.groupRoomId).toString("base64").replace(/=/g, "");
-    this.confUserId = "@" + USER_PREFIX + this.base64RoomId + ":" + DOMAIN;
+    var base64RoomId = new Buffer(groupChatRoomId).toString("base64").replace(/=/g, "");
+    this.confUserId = "@" + USER_PREFIX + base64RoomId + ":" + DOMAIN;
 }
 
-ConferenceHandler.prototype.setup = function() {
+ConferenceCall.prototype.setup = function() {
     var self = this;
     return this._joinConferenceUser().then(function() {
         return self._getConferenceUserRoom();
@@ -24,7 +24,7 @@ ConferenceHandler.prototype.setup = function() {
     });
 };
 
-ConferenceHandler.prototype._joinConferenceUser = function() {
+ConferenceCall.prototype._joinConferenceUser = function() {
     // Make sure the conference user is in the group chat room
     var groupRoom = this.client.getRoom(this.groupRoomId);
     if (!groupRoom) {
@@ -37,7 +37,7 @@ ConferenceHandler.prototype._joinConferenceUser = function() {
     return this.client.invite(this.groupRoomId, this.confUserId);
 };
 
-ConferenceHandler.prototype._getConferenceUserRoom = function() {
+ConferenceCall.prototype._getConferenceUserRoom = function() {
     // Use an existing 1:1 with the conference user; else make one
     var rooms = this.client.getRooms();
     var confRoom = null;
@@ -60,5 +60,23 @@ ConferenceHandler.prototype._getConferenceUserRoom = function() {
     });
 };
 
-module.exports = ConferenceHandler;
+/**
+ * Check if this room member is in fact a conference bot.
+ * @param {RoomMember} The room member to check
+ * @return {boolean} True if it is a conference bot.
+ */
+module.exports.isConferenceUser = function(roomMember) {
+    if (roomMember.userId.indexOf("@" + USER_PREFIX) !== 0) {
+        return false;
+    }
+    var base64part = roomMember.userId.split(":")[0].substring(1 + USER_PREFIX.length);
+    if (base64part) {
+        var decoded = new Buffer(base64part, "base64").toString();
+        // ! $STUFF : $STUFF
+        return /^!.+:.+/.test(decoded);
+    }
+    return false;
+};
+
+module.exports.ConferenceCall = ConferenceCall;
 

--- a/src/controllers/molecules/RoomHeader.js
+++ b/src/controllers/molecules/RoomHeader.js
@@ -27,7 +27,6 @@ limitations under the License.
 var React = require('react');
 var dis = require("../../dispatcher");
 var CallHandler = require("../../CallHandler");
-var ConferenceHandler = require("../../ConferenceHandler");
 
 module.exports = {
     propTypes: {
@@ -48,7 +47,7 @@ module.exports = {
     componentDidMount: function() {
         this.dispatcherRef = dis.register(this.onAction);
         if (this.props.room) {
-            var call = this._getCall(this.props.room.roomId);
+            var call = CallHandler.getCallForRoom(this.props.room.roomId);
             var callState = call ? call.call_state : "ended";
             this.setState({
                 call_state: callState
@@ -66,7 +65,7 @@ module.exports = {
         if (payload.action !== 'call_state' || !payload.room_id) {
             return;
         }
-        var call = this._getCall(payload.room_id);
+        var call = CallHandler.getCallForRoom(payload.room_id);
         var callState = call ? call.call_state : "ended";
         this.setState({
             call_state: callState
@@ -88,7 +87,7 @@ module.exports = {
         });
     },
     onHangupClick: function() {
-        var call = this._getCall(this.props.room.roomId);
+        var call = CallHandler.getCallForRoom(this.props.room.roomId);
         if (!call) { return; }
         dis.dispatch({
             action: 'hangup',
@@ -96,22 +95,5 @@ module.exports = {
             // (e.g. conferences which will hangup the 1:1 room instead)
             room_id: call.roomId
         });
-    },
-
-    _getCall: function(roomId) {
-        var call = CallHandler.getCall(roomId);
-        if (!call) {
-            // search for a conference 1:1 call
-            var activeCall = CallHandler.getAnyActiveCall();
-            if (activeCall && activeCall.confUserId) {
-                var thisRoomConfUserId = ConferenceHandler.getConferenceUserIdForRoom(
-                    roomId
-                );
-                if (thisRoomConfUserId === activeCall.confUserId) {
-                    call = activeCall;
-                }
-            }
-        }
-        return call;
     }
 };

--- a/src/controllers/molecules/voip/CallView.js
+++ b/src/controllers/molecules/voip/CallView.js
@@ -57,19 +57,16 @@ module.exports = {
     },
 
     onAction: function(payload) {
-        // if we were given a room_id to track, don't handle anything else.
-        if (payload.room_id && this._trackedRoom &&
-                this._trackedRoom.roomId !== payload.room_id) {
-            return;
-        }
-        if (payload.action !== 'call_state') {
+        // don't filter out payloads for room IDs other than props.room because
+        // we may be interested in the conf 1:1 room
+        if (payload.action !== 'call_state' || !payload.room_id) {
             return;
         }
         this.showCall(payload.room_id);
     },
 
     showCall: function(roomId) {
-        var call = CallHandler.getCall(roomId);
+        var call = CallHandler.getCallForRoom(roomId);
         if (call) {
             call.setLocalVideoElement(this.getVideoView().getLocalVideoElement());
             // N.B. the remote video element is used for playback for audio for voice calls

--- a/src/controllers/molecules/voip/CallView.js
+++ b/src/controllers/molecules/voip/CallView.js
@@ -73,7 +73,11 @@ module.exports = {
             call.setRemoteVideoElement(this.getVideoView().getRemoteVideoElement());
         }
         if (call && call.type === "video" && call.state !== 'ended') {
-            this.getVideoView().getLocalVideoElement().style.display = "initial";
+            // if this call is a conf call, don't display local video as the
+            // conference will have us in it
+            this.getVideoView().getLocalVideoElement().style.display = (
+                call.confUserId ? "none" : "initial"
+            );
             this.getVideoView().getRemoteVideoElement().style.display = "initial";
         }
         else {

--- a/src/controllers/organisms/RoomList.js
+++ b/src/controllers/organisms/RoomList.js
@@ -99,9 +99,9 @@ module.exports = {
     getRoomList: function() {
         return RoomListSorter.mostRecentActivityFirst(
             MatrixClientPeg.get().getRooms().filter(function(room) {
-                var member = room.getMember(MatrixClientPeg.get().credentials.userId);
+                var me = room.getMember(MatrixClientPeg.get().credentials.userId);
                 var shouldShowRoom =  (
-                    member && (member.membership == "join" || member.membership == "invite")
+                    me && (me.membership == "join" || me.membership == "invite")
                 );
                 // hiding conf rooms only ever toggles shouldShowRoom to false
                 if (shouldShowRoom && HIDE_CONFERENCE_CHANS) {
@@ -109,7 +109,7 @@ module.exports = {
                     var joinedMembers = room.getJoinedMembers();
                     if (joinedMembers.length === 2) {
                         var otherMember = joinedMembers.filter(function(m) {
-                            return m.userId !== member.userId
+                            return m.userId !== me.userId
                         })[0];
                         if (ConferenceHandler.isConferenceUser(otherMember)) {
                             // console.log("Hiding conference 1:1 room %s", room.roomId);

--- a/src/controllers/organisms/RoomList.js
+++ b/src/controllers/organisms/RoomList.js
@@ -112,7 +112,7 @@ module.exports = {
                             return m.userId !== member.userId
                         })[0];
                         if (ConferenceHandler.isConferenceUser(otherMember)) {
-                            console.log("Hiding conference 1:1 room %s", room.roomId);
+                            // console.log("Hiding conference 1:1 room %s", room.roomId);
                             shouldShowRoom = false;
                         }
                     }

--- a/src/controllers/organisms/RoomView.js
+++ b/src/controllers/organisms/RoomView.js
@@ -31,7 +31,8 @@ var dis = require("../../dispatcher");
 var PAGINATE_SIZE = 20;
 var INITIAL_SIZE = 100;
 
-var ComponentBroker = require('../../ComponentBroker');
+var ConferenceHandler = require("../../ConferenceHandler");
+var CallHandler = require("../../CallHandler");
 var Notifier = ComponentBroker.get('organisms/Notifier');
 
 var tileTypes = {
@@ -62,6 +63,7 @@ module.exports = {
         MatrixClientPeg.get().on("Room.timeline", this.onRoomTimeline);
         MatrixClientPeg.get().on("Room.name", this.onRoomName);
         MatrixClientPeg.get().on("RoomMember.typing", this.onRoomMemberTyping);
+        MatrixClientPeg.get().on("RoomState.members", this.onRoomStateMember);
         this.atBottom = true;
     },
 
@@ -78,6 +80,7 @@ module.exports = {
             MatrixClientPeg.get().removeListener("Room.timeline", this.onRoomTimeline);
             MatrixClientPeg.get().removeListener("Room.name", this.onRoomName);
             MatrixClientPeg.get().removeListener("RoomMember.typing", this.onRoomMemberTyping);
+            MatrixClientPeg.get().removeListener("RoomState.members", this.onRoomStateMember);
         }
     },
 
@@ -94,15 +97,20 @@ module.exports = {
                 this.forceUpdate();
                 break;
             case 'call_state':
-                if (this.props.roomId !== payload.room_id) {
-                    break;
+                if (CallHandler.getCallForRoom(this.props.roomId)) {
+                    // Call state has changed so we may be loading video elements
+                    // which will obscure the message log.
+                    // scroll to bottom
+                    var messageWrapper = this.refs.messageWrapper;
+                    if (messageWrapper) {
+                        messageWrapper = messageWrapper.getDOMNode();
+                        messageWrapper.scrollTop = messageWrapper.scrollHeight;
+                    }
                 }
-                // scroll to bottom
-                var messageWrapper = this.refs.messageWrapper;
-                if (messageWrapper) {
-                    messageWrapper = messageWrapper.getDOMNode();
-                    messageWrapper.scrollTop = messageWrapper.scrollHeight;
-                }
+
+                // possibly remove the conf call notification if we're now in
+                // the conf
+                this._updateConfCallNotification();
                 break;
         }
     },
@@ -170,6 +178,35 @@ module.exports = {
         this.forceUpdate();
     },
 
+    onRoomStateMember: function(ev, state, member) {
+        if (member.roomId !== this.props.roomId ||
+                member.userId !== ConferenceHandler.getConferenceUserIdForRoom(member.roomId)) {
+            return;
+        }
+        this._updateConfCallNotification();
+    },
+
+    _updateConfCallNotification: function() {
+        var member = MatrixClientPeg.get().getRoom(this.props.roomId).getMember(
+            ConferenceHandler.getConferenceUserIdForRoom(this.props.roomId)
+        );
+
+        if (!member) {
+            return;
+        }
+        console.log("_updateConfCallNotification");
+        var confCall = CallHandler.getConferenceCall(member.roomId);
+
+        // A conf call notification should be displayed if there is an ongoing
+        // conf call but this cilent isn't a part of it.
+        this.setState({
+            displayConfCallNotification: (
+                (!confCall || confCall.call_state === "ended") &&
+                member.membership === "join"
+            )
+        });
+    },
+
     componentDidMount: function() {
         if (this.refs.messageWrapper) {
             var messageWrapper = this.refs.messageWrapper.getDOMNode();
@@ -183,6 +220,7 @@ module.exports = {
 
             this.fillSpace();
         }
+        this._updateConfCallNotification();
     },
 
     componentDidUpdate: function() {

--- a/src/controllers/organisms/RoomView.js
+++ b/src/controllers/organisms/RoomView.js
@@ -206,6 +206,14 @@ module.exports = {
         });
     },
 
+    onConferenceNotificationClick: function() {
+        dis.dispatch({
+            action: 'place_call',
+            type: "video",
+            room_id: this.props.roomId
+        });
+    },
+
     componentDidMount: function() {
         if (this.refs.messageWrapper) {
             var messageWrapper = this.refs.messageWrapper.getDOMNode();

--- a/src/controllers/organisms/RoomView.js
+++ b/src/controllers/organisms/RoomView.js
@@ -187,22 +187,21 @@ module.exports = {
     },
 
     _updateConfCallNotification: function() {
-        var member = MatrixClientPeg.get().getRoom(this.props.roomId).getMember(
+        var confMember = MatrixClientPeg.get().getRoom(this.props.roomId).getMember(
             ConferenceHandler.getConferenceUserIdForRoom(this.props.roomId)
         );
 
-        if (!member) {
+        if (!confMember) {
             return;
         }
-        console.log("_updateConfCallNotification");
-        var confCall = CallHandler.getConferenceCall(member.roomId);
+        var confCall = CallHandler.getConferenceCall(confMember.roomId);
 
         // A conf call notification should be displayed if there is an ongoing
         // conf call but this cilent isn't a part of it.
         this.setState({
             displayConfCallNotification: (
                 (!confCall || confCall.call_state === "ended") &&
-                member.membership === "join"
+                confMember.membership === "join"
             )
         });
     },

--- a/src/controllers/pages/MatrixChat.js
+++ b/src/controllers/pages/MatrixChat.js
@@ -26,6 +26,7 @@ var dis = require("../../dispatcher");
 var q = require("q");
 
 var ComponentBroker = require('../../ComponentBroker');
+var CallHandler = require("../../CallHandler");
 var Notifier = ComponentBroker.get('organisms/Notifier');
 var MatrixTools = require('../../MatrixTools');
 
@@ -204,6 +205,13 @@ module.exports = {
                 break;
             case 'notifier_enabled':
                 this.forceUpdate();
+                break;
+            case 'call_state':
+                // listen for call state changes to prod the render method, which
+                // may hide the global CallView if the call it is tracking is dead
+                this.setState({
+                    active_call: CallHandler.getAnyActiveCall()
+                });
                 break;
         }
     },

--- a/src/controllers/pages/MatrixChat.js
+++ b/src/controllers/pages/MatrixChat.js
@@ -26,7 +26,6 @@ var dis = require("../../dispatcher");
 var q = require("q");
 
 var ComponentBroker = require('../../ComponentBroker');
-var CallHandler = require("../../CallHandler");
 var Notifier = ComponentBroker.get('organisms/Notifier');
 var MatrixTools = require('../../MatrixTools');
 
@@ -205,13 +204,6 @@ module.exports = {
                 break;
             case 'notifier_enabled':
                 this.forceUpdate();
-                break;
-            case 'call_state':
-                // listen for call state changes to prod the render method, which
-                // may hide the global CallView if the call it is tracking is dead
-                this.setState({
-                    active_call: CallHandler.getAnyActiveCall()
-                });
                 break;
         }
     },


### PR DESCRIPTION
This PR adds conferencing support to vector for HSes running https://github.com/matrix-org/matrix-appservice-verto (which matrix.org is)

Conferencing from the end-user's perspective:
 - Group chats may now have an "Ongoing conference call" notification on them.
 - Placing a voice or video call to the group chat room will no longer produce an error but will connect the client to a conference for that room.
 - Even if there is no "ongoing" notification, you can start a conference by just doing a voice/video call to the group chat room. This will invite a special conference user (part of the Verto AS) to mediate the conference call and provide ACLs on the conference call (so when you leave the group chat room, you get booted from the conference call). Semantics are the same as 1:1 calling (there is an end call button, etc).

Conferencing from a tech perspective:
 - The call is a faux 1:1 WebRTC call to the "special conference user" which has a programatically-determinable user ID of `@fs_$BASE-64-ROOM-ID:matrix.org`. The call is done in a 1:1 room with the conference user which is hidden from the recents list. In the future, we may want to expose this to provide floor control (muting/etc)
 - When the call is placed to this user, it will attempt to join the group chat room it is providing conferencing support to (it knows the room ID because its' user ID contains it!). It must be able to join the room in order for conferencing to work (this is why Vector by default will invite the user even if it is a public room).
 - When there are no more users on the conference call, the "special conference user" leaves the room. The state of the "special conference user" determines whether there is an "ongoing conference call" or not.

Additional notes:
 - This PR also fixes https://github.com/vector-im/vector-web/issues/31 - but the CSS for overlaying video needs to be done.
 - This PR also properly enforces single-call semantics (previously it was erroneously possible to place multiple calls(!))
 - There are a number of new configuration constants in SHOUTY_CAPS which determine the `user_id` format for the "special conference users" - we need to split this out into a config file for use at compile time ideally.

It has been manually tested for inbound and outbound calls, with changing rooms for each.