### PR TITLE
Add support for CAS auth

### DIFF
--- a/src/skins/vector/skindex.js
+++ b/src/skins/vector/skindex.js
@@ -64,6 +64,7 @@ skin['molecules.UserSelector'] = require('./views/molecules/UserSelector');
 skin['molecules.voip.CallView'] = require('./views/molecules/voip/CallView');
 skin['molecules.voip.IncomingCallBox'] = require('./views/molecules/voip/IncomingCallBox');
 skin['molecules.voip.VideoView'] = require('./views/molecules/voip/VideoView');
+skin['organisms.CasLogin'] = require('./views/organisms/CasLogin');
 skin['organisms.CreateRoom'] = require('./views/organisms/CreateRoom');
 skin['organisms.ErrorDialog'] = require('./views/organisms/ErrorDialog');
 skin['organisms.LeftPanel'] = require('./views/organisms/LeftPanel');

--- a/src/skins/vector/views/organisms/CasLogin.js
+++ b/src/skins/vector/views/organisms/CasLogin.js
@@ -33,6 +33,5 @@ module.exports = React.createClass({
             </div>
         );
     },
-    
-});
 
+});

--- a/src/skins/vector/views/organisms/CasLogin.js
+++ b/src/skins/vector/views/organisms/CasLogin.js
@@ -20,25 +20,11 @@ var React = require('react');
 
 var MatrixClientPeg = require('matrix-react-sdk/lib/MatrixClientPeg');
 
+var CasLoginController = require('matrix-react-sdk/lib/controllers/organisms/CasLogin');
+
 module.exports = React.createClass({
     displayName: 'CasLogin',
-
-    getInitialState: function() {
-        var splitLocation = window.location.href.split('/');
-        return {serviceUrl: splitLocation[0] + "//" + splitLocation[2]};
-    },
-
-    onCasClicked: function(ev) {
-        var serviceRedirectUrl = this.state.serviceUrl + "/#/login/cas";
-        var self = this;
-        MatrixClientPeg.get().getCasServer().done(function(data) {
-            var serverUrl = data.serverUrl + "/login?service=" + encodeURIComponent(serviceRedirectUrl);
-            window.location.href=serverUrl
-        }, function(error) {
-            self.setStep("stage_m.login.cas");
-            self.setState({errorText: 'Login failed.'});
-        });
-    },
+    mixins: [CasLoginController],
 
     render: function() {
         return (
@@ -47,4 +33,5 @@ module.exports = React.createClass({
             </div>
         );
     }
+    
 });

--- a/src/skins/vector/views/organisms/CasLogin.js
+++ b/src/skins/vector/views/organisms/CasLogin.js
@@ -1,0 +1,50 @@
+/*
+Copyright 2015 OpenMarket Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+'use strict';
+
+var React = require('react');
+
+var MatrixClientPeg = require('matrix-react-sdk/lib/MatrixClientPeg');
+
+module.exports = React.createClass({
+    displayName: 'CasLogin',
+
+    getInitialState: function() {
+        var splitLocation = window.location.href.split('/');
+        return {serviceUrl: splitLocation[0] + "//" + splitLocation[2]};
+    },
+
+    onCasClicked: function(ev) {
+        var serviceRedirectUrl = this.state.serviceUrl + "/#/login/cas";
+        var self = this;
+        MatrixClientPeg.get().getCasServer().done(function(data) {
+            var serverUrl = data.serverUrl + "/login?service=" + encodeURIComponent(serviceRedirectUrl);
+            window.location.href=serverUrl
+        }, function(error) {
+            self.setStep("stage_m.login.cas");
+            self.setState({errorText: 'Login failed.'});
+        });
+    },
+
+    render: function() {
+        return (
+            <div>
+                <button onClick={this.onCasClicked}>Sign in with CAS</button>
+            </div>
+        );
+    }
+});

--- a/src/skins/vector/views/organisms/CasLogin.js
+++ b/src/skins/vector/views/organisms/CasLogin.js
@@ -32,6 +32,7 @@ module.exports = React.createClass({
                 <button onClick={this.onCasClicked}>Sign in with CAS</button>
             </div>
         );
-    }
+    },
     
 });
+

--- a/src/skins/vector/views/templates/Login.js
+++ b/src/skins/vector/views/templates/Login.js
@@ -141,6 +141,11 @@ module.exports = React.createClass({
                         </form>
                     </div>
                 );
+            case 'stage_m.login.cas':
+                var CasLogin = sdk.getComponent('organisms.CasLogin');
+                return (
+                    <CasLogin />
+                );
         }
     },
 

--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -23,22 +23,29 @@ sdk.loadModule(require('../modules/VectorConferenceHandler'));
 
 var lastLocationHashSet = null;
 
+
+function parseQueryParams(location) {
+    var hashparts = location.hash.split('?');
+    var params = {};
+    if (hashparts.length == 2) {
+        var pairs = hashparts[1].split('&');
+        for (var i = 0; i < pairs.length; ++i) {
+            var parts = pairs[i].split('=');
+            if (parts.length != 2) continue;
+            params[decodeURIComponent(parts[0])] = decodeURIComponent(parts[1]);
+        }
+    }
+    return params
+}
+
 // Here, we do some crude URL analysis to allow
 // deep-linking. We only support registration
 // deep-links in this example.
 function routeUrl(location) {
     if (location.hash.indexOf('#/register') == 0) {
-        var hashparts = location.hash.split('?');
-        var params = {};
-        if (hashparts.length == 2) {
-            var pairs = hashparts[1].split('&');
-            for (var i = 0; i < pairs.length; ++i) {
-                var parts = pairs[i].split('=');
-                if (parts.length != 2) continue;
-                params[decodeURIComponent(parts[0])] = decodeURIComponent(parts[1]);
-            }
-        }
-        window.matrixChat.showScreen('register', params);
+        window.matrixChat.showScreen('register', parseQueryParams(location));
+    } else if (location.hash.indexOf('#/login/cas') == 0) {
+        window.matrixChat.showScreen('cas_login', parseQueryParams(location));
     } else {
         window.matrixChat.showScreen(location.hash.substring(2));
     }

--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -21,21 +21,20 @@ var sdk = require("matrix-react-sdk");
 sdk.loadSkin(require('../skins/vector/skindex'));
 sdk.loadModule(require('../modules/VectorConferenceHandler'));
 
+var qs = require("querystring");
+
 var lastLocationHashSet = null;
 
 
-function parseQueryParams(location) {
+// We want to support some name / value pairs in the fragment
+// so we're re-using query string ike format
+function parseQsFromFragment(location) {
     var hashparts = location.hash.split('?');
-    var params = {};
-    if (hashparts.length == 2) {
-        var pairs = hashparts[1].split('&');
-        for (var i = 0; i < pairs.length; ++i) {
-            var parts = pairs[i].split('=');
-            if (parts.length != 2) continue;
-            params[decodeURIComponent(parts[0])] = decodeURIComponent(parts[1]);
-        }
+    if (hashparts.length > 1) {
+        console.log(qs.parse(hashparts[1]));
+        return qs.parse(hashparts[1]);
     }
-    return params
+    return {};
 }
 
 // Here, we do some crude URL analysis to allow
@@ -43,9 +42,9 @@ function parseQueryParams(location) {
 // deep-links in this example.
 function routeUrl(location) {
     if (location.hash.indexOf('#/register') == 0) {
-        window.matrixChat.showScreen('register', parseQueryParams(location));
+        window.matrixChat.showScreen('register', parseQsFromFragment(location));
     } else if (location.hash.indexOf('#/login/cas') == 0) {
-        window.matrixChat.showScreen('cas_login', parseQueryParams(location));
+        window.matrixChat.showScreen('cas_login', parseQsFromFragment(location));
     } else {
         window.matrixChat.showScreen(location.hash.substring(2));
     }

--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -27,11 +27,10 @@ var lastLocationHashSet = null;
 
 
 // We want to support some name / value pairs in the fragment
-// so we're re-using query string ike format
+// so we're re-using query string like format
 function parseQsFromFragment(location) {
     var hashparts = location.hash.split('?');
     if (hashparts.length > 1) {
-        console.log(qs.parse(hashparts[1]));
         return qs.parse(hashparts[1]);
     }
     return {};


### PR DESCRIPTION
Initial and basic CAS login.

Flow is:
 - User clicks login with CAS
 - Vector requests CAS server URL from HS
 - Vector redirects user to CAS server
 - CAS redirects back to Vector with ticketId
 - Vector sends ticket ID to HS
 - HS verifies ticket ID with CAS
 - Login Success

Doesn't do anything with logout yet.
Also, the CAS login page will only be shown if CAS is the first login flow returned from the HS

Tested locally and works.

No doubt plenty of room for improvement on this works but it's a starting point and I'm happy to be given pointers for improvements before it get's merged!

Related to:
https://github.com/matrix-org/synapse/pull/295
https://github.com/matrix-org/matrix-js-sdk/pull/20
https://github.com/matrix-org/matrix-react-sdk/pull/19

Signed-off-by: Steven Hammerton steven.hammerton@openmarket.com