### PR TITLE
Fix inbound audio

### DIFF
--- a/src/skins/vector/views/molecules/voip/IncomingCallBox.js
+++ b/src/skins/vector/views/molecules/voip/IncomingCallBox.js
@@ -32,11 +32,10 @@ module.exports = React.createClass({
 
     render: function() {
 
-        // NB: This block MUST be the first thing inside the <div> else react won't
-        // know that they refer to the same thing and so will clobber them between
-        // in-call / not-in-call resulting in no inbound audio.
+        // NB: This block MUST have a "key" so React doesn't clobber the elements
+        // between in-call / not-in-call.
         var audioBlock = (
-            <audio ref="ringAudio" loop>
+            <audio ref="ringAudio" key="voip_ring_audio" loop>
                 <source src="media/ring.ogg" type="audio/ogg" />
                 <source src="media/ring.mp3" type="audio/mpeg" />
             </audio>

--- a/src/skins/vector/views/molecules/voip/IncomingCallBox.js
+++ b/src/skins/vector/views/molecules/voip/IncomingCallBox.js
@@ -31,24 +31,29 @@ module.exports = React.createClass({
     },
 
     render: function() {
+
+        // NB: This block MUST be the first thing inside the <div> else react won't
+        // know that they refer to the same thing and so will clobber them between
+        // in-call / not-in-call resulting in no inbound audio.
+        var audioBlock = (
+            <audio ref="ringAudio" loop>
+                <source src="media/ring.ogg" type="audio/ogg" />
+                <source src="media/ring.mp3" type="audio/mpeg" />
+            </audio>
+        );
+
         if (!this.state.incomingCall || !this.state.incomingCall.roomId) {
             return (
                 <div>
-                    <audio ref="ringAudio" loop>
-                        <source src="media/ring.ogg" type="audio/ogg" />
-                        <source src="media/ring.mp3" type="audio/mpeg" />
-                    </audio>
+                    {audioBlock}
                 </div>
             );
         }
         var caller = MatrixClientPeg.get().getRoom(this.state.incomingCall.roomId).name;
         return (
             <div className="mx_IncomingCallBox">
+                {audioBlock}
                 <img className="mx_IncomingCallBox_chevron" src="img/chevron-left.png" width="9" height="16" />
-                <audio ref="ringAudio" loop>
-                    <source src="media/ring.ogg" type="audio/ogg" />
-                    <source src="media/ring.mp3" type="audio/mpeg" />
-                </audio>
                 <div className="mx_IncomingCallBox_title">
                     Incoming { this.state.incomingCall ? this.state.incomingCall.type : '' } call from { caller }
                 </div>


### PR DESCRIPTION
This was caused by an \<img> being the first thing in the \<div> rather than
the \<audio>. This caused a conflict because the "not in call" render was just
\<div>\<audio />\</div> and "in call" render was \<div>\<img /> \<audio />\</div>

React can't tell in this case that the \<audio> tags are the "same" so was
clobbering it (which meant that on inbound calls we would call play() on an
audio tag which would then immediately be clobbered by another audio tag).

Fixes #228