### PR TITLE
Make unsent messages behave better

### DIFF
--- a/src/components/views/rooms/MessageContextMenu.js
+++ b/src/components/views/rooms/MessageContextMenu.js
@@ -57,25 +57,41 @@ module.exports = React.createClass({
         if (this.props.onFinished) this.props.onFinished();
     },
 
+    onCancelSendClick: function() {
+        Resend.removeFromQueue(this.props.mxEvent);
+    },
+
     render: function() {
+        var eventStatus = this.props.mxEvent.status;
         var resendButton;
         var viewSourceButton;
         var redactButton;
+        var cancelButton;
 
-        if (this.props.mxEvent.status == 'not_sent') {
+        if (eventStatus === 'not_sent') {
             resendButton = (
                 <div className="mx_ContextualMenu_field" onClick={this.onResendClick}>
                     Resend
                 </div>
             );
         }
-        else {
+
+        if (!eventStatus) { // sent
             redactButton = (
                 <div className="mx_ContextualMenu_field" onClick={this.onRedactClick}>
                     Redact
                 </div>
             );
         }
+
+        if (eventStatus === "queued") {
+            cancelButton = (
+                <div className="mx_ContextualMenu_field" onClick={this.onCancelSendClick}>
+                    Cancel Sending
+                </div>
+            );
+        }
+
         viewSourceButton = (
             <div className="mx_ContextualMenu_field" onClick={this.onViewSourceClick}>
                 View Source
@@ -86,6 +102,7 @@ module.exports = React.createClass({
             <div>
                 {resendButton}
                 {redactButton}
+                {cancelButton}
                 {viewSourceButton}
             </div>
         );

--- a/src/components/views/rooms/MessageContextMenu.js
+++ b/src/components/views/rooms/MessageContextMenu.js
@@ -84,7 +84,7 @@ module.exports = React.createClass({
             );
         }
 
-        if (eventStatus === "queued") {
+        if (eventStatus === "queued" || eventStatus === "not_sent") {
             cancelButton = (
                 <div className="mx_ContextualMenu_field" onClick={this.onCancelSendClick}>
                     Cancel Sending

--- a/src/components/views/rooms/MessageContextMenu.js
+++ b/src/components/views/rooms/MessageContextMenu.js
@@ -59,6 +59,7 @@ module.exports = React.createClass({
 
     onCancelSendClick: function() {
         Resend.removeFromQueue(this.props.mxEvent);
+        if (this.props.onFinished) this.props.onFinished();
     },
 
     render: function() {

--- a/src/skins/vector/css/molecules/EventTile.css
+++ b/src/skins/vector/css/molecules/EventTile.css
@@ -111,7 +111,7 @@ limitations under the License.
 }
 
 .mx_EventTile_notSent {
-    color: #ddd;
+    color: #f44;
 }
 
 .mx_EventTile_highlight,


### PR DESCRIPTION
Fixes https://github.com/vector-im/vector-web/issues/367 . Specifically:
 - Add "Cancel Sending" to all `NOT_SENT` and `QUEUED` messages.
 - Make all `SENDING` `NOT_SENT` and `QUEUED` messages appear at the end of the timeline.
 - Make the distinction between `NOT_SENT` and `SENDING` clearer by making `NOT_SENT` text red as it was before. It was removed because:

  > M-matthew> kegan: i did it deliberately to match the ribot design [...] ribot are concerned that bright red is too vicious, and i'm inclined to agree

  I've reverted this because it is incredibly confusing otherwise:

  > you sit there like a lemon waiting for something to send which never will
  > M-matthew> if you feel that strongly about it feel free to back it out

  We need **some indication**. Whether this is red text, an exclamation icon, something, I don't care. But nothing is not acceptable.

This relies on the following PRs:
 - https://github.com/matrix-org/matrix-react-sdk/pull/47
 - https://github.com/matrix-org/matrix-js-sdk/pull/51