### PR TITLE
Pass a userId rather than a RoomMember to isConferenceUser

### DIFF
--- a/src/VectorConferenceHandler.js
+++ b/src/VectorConferenceHandler.js
@@ -85,15 +85,15 @@ ConferenceCall.prototype._getConferenceUserRoom = function() {
 };
 
 /**
- * Check if this room member is in fact a conference bot.
- * @param {RoomMember} The room member to check
+ * Check if this user ID is in fact a conference bot.
+ * @param {string} userId The user ID to check.
  * @return {boolean} True if it is a conference bot.
  */
-module.exports.isConferenceUser = function(roomMember) {
-    if (roomMember.userId.indexOf("@" + USER_PREFIX) !== 0) {
+module.exports.isConferenceUser = function(userId) {
+    if (userId.indexOf("@" + USER_PREFIX) !== 0) {
         return false;
     }
-    var base64part = roomMember.userId.split(":")[0].substring(1 + USER_PREFIX.length);
+    var base64part = userId.split(":")[0].substring(1 + USER_PREFIX.length);
     if (base64part) {
         var decoded = new Buffer(base64part, "base64").toString();
         // ! $STUFF : $STUFF


### PR DESCRIPTION
Because invites do not have RoomMembers because we don't have an m.room.member
event for them, just a user ID, and we want to detect conf users at invite
time.

Fixes https://github.com/vector-im/vector-web/issues/510
Depends on https://github.com/matrix-org/matrix-react-sdk/pull/54