### PR TITLE
Add more props to RoomSubList

### DIFF
--- a/src/components/structures/RoomSubList.js
+++ b/src/components/structures/RoomSubList.js
@@ -61,7 +61,6 @@ var RoomSubList = React.createClass({
         tagName: React.PropTypes.string,
         editable: React.PropTypes.bool,
         order: React.PropTypes.string.isRequired,
-        bottommost: React.PropTypes.bool,
         selectedRoom: React.PropTypes.string.isRequired,
         activityMap: React.PropTypes.object.isRequired,
         startAsHidden: React.PropTypes.bool,
@@ -290,8 +289,7 @@ var RoomSubList = React.createClass({
 
         if (this.state.sortedList.length > 0 || this.props.editable) {
             var subList;
-            var classes = "mx_RoomSubList" +
-                          (this.props.bottommost ? " mx_RoomSubList_bottommost" : "");
+            var classes = "mx_RoomSubList";
 
             if (!this.state.hidden) {
                 subList = <div className={ classes }>

--- a/src/components/structures/RoomSubList.js
+++ b/src/components/structures/RoomSubList.js
@@ -64,13 +64,21 @@ var RoomSubList = React.createClass({
         bottommost: React.PropTypes.bool,
         selectedRoom: React.PropTypes.string.isRequired,
         activityMap: React.PropTypes.object.isRequired,
-        collapsed: React.PropTypes.bool.isRequired
+        collapsed: React.PropTypes.bool.isRequired,
+        onHeaderClick: React.PropTypes.func,
+        alwaysShowHeader: React.PropTypes.bool
     },
 
     getInitialState: function() {
         return {
             hidden: false,
             sortedList: [],
+        };
+    },
+
+    getDefaultProps: function() {
+        return {
+            onHeaderClick: function() {} // NOP
         };
     },
 
@@ -85,7 +93,9 @@ var RoomSubList = React.createClass({
     },
 
     onClick: function(ev) {
-        this.setState({ hidden : !this.state.hidden });
+        var isHidden = !this.state.hidden;
+        this.setState({ hidden : isHidden });
+        this.props.onHeaderClick(isHidden);
     },
 
     tsOfNewestEvent: function(room) {
@@ -244,6 +254,17 @@ var RoomSubList = React.createClass({
         });
     },
 
+    _getHeaderJsx: function() {
+        return (
+            <h2 onClick={ this.onClick } className="mx_RoomSubList_label">
+                { this.props.collapsed ? '' : this.props.label }
+                <img className="mx_RoomSubList_chevron"
+                    src={ this.state.hidden ? "img/list-open.svg" : "img/list-close.svg" }
+                    width="10" height="10" />
+            </h2>
+        );
+    },
+
     render: function() {
         var connectDropTarget = this.props.connectDropTarget;
         var RoomDropTarget = sdk.getComponent('rooms.RoomDropTarget');
@@ -275,9 +296,7 @@ var RoomSubList = React.createClass({
 
             return connectDropTarget(
                 <div>
-                    <h2 onClick={ this.onClick } className="mx_RoomSubList_label">{ this.props.collapsed ? '' : this.props.label }
-                        <img className="mx_RoomSubList_chevron" src={ this.state.hidden ? "img/list-open.svg" : "img/list-close.svg" } width="10" height="10"/>
-                    </h2>
+                    { this._getHeaderJsx() }
                     { subList }
                 </div>
             );
@@ -285,6 +304,7 @@ var RoomSubList = React.createClass({
         else {
             return (
                 <div className="mx_RoomSubList">
+                    { this.props.alwaysShowHeader ? this._getHeaderJsx() : undefined }
                 </div>
             );
         }

--- a/src/components/structures/RoomSubList.js
+++ b/src/components/structures/RoomSubList.js
@@ -64,6 +64,8 @@ var RoomSubList = React.createClass({
         bottommost: React.PropTypes.bool,
         selectedRoom: React.PropTypes.string.isRequired,
         activityMap: React.PropTypes.object.isRequired,
+        startAsHidden: React.PropTypes.bool,
+        showSpinner: React.PropTypes.bool, // true to show a spinner if 0 elements when expanded
 
         // TODO: Fix the name of this. This is too easily confused with the
         // "hidden" state which is the expanded (or not) view of the list of rooms.
@@ -76,7 +78,7 @@ var RoomSubList = React.createClass({
 
     getInitialState: function() {
         return {
-            hidden: false,
+            hidden: this.props.startAsHidden || false,
             sortedList: [],
         };
     },
@@ -307,9 +309,11 @@ var RoomSubList = React.createClass({
             );
         }
         else {
+            var Loader = sdk.getComponent("elements.Spinner");
             return (
                 <div className="mx_RoomSubList">
                     { this.props.alwaysShowHeader ? this._getHeaderJsx() : undefined }
+                    { (this.props.showSpinner && !this.state.hidden) ? <Loader /> : undefined }
                 </div>
             );
         }

--- a/src/components/structures/RoomSubList.js
+++ b/src/components/structures/RoomSubList.js
@@ -64,6 +64,11 @@ var RoomSubList = React.createClass({
         bottommost: React.PropTypes.bool,
         selectedRoom: React.PropTypes.string.isRequired,
         activityMap: React.PropTypes.object.isRequired,
+
+        // TODO: Fix the name of this. This is too easily confused with the
+        // "hidden" state which is the expanded (or not) view of the list of rooms.
+        // What this prop *really* does is control whether the room name is displayed
+        // so it should be named as such.
         collapsed: React.PropTypes.bool.isRequired,
         onHeaderClick: React.PropTypes.func,
         alwaysShowHeader: React.PropTypes.bool

--- a/src/skins/vector/css/organisms/RoomList.css
+++ b/src/skins/vector/css/organisms/RoomList.css
@@ -17,6 +17,7 @@ limitations under the License.
 .mx_RoomList {
     padding-top: 24px;
     padding-bottom: 12px;
+    min-height: 400px;
 }
 
 .mx_RoomList_expandButton {

--- a/src/skins/vector/css/organisms/RoomSubList.css
+++ b/src/skins/vector/css/organisms/RoomSubList.css
@@ -20,11 +20,6 @@ limitations under the License.
     width: 100%;
 }
 
-.mx_RoomSubList_bottommost {
-    /* XXX: this should really be 100% of the RoomList height, but can't seem to get at it */
-    min-height: 400px;
-}
-
 .mx_RoomSubList_label {
     text-transform: uppercase;
     color: #3d3b39;


### PR DESCRIPTION
Part of the fix for https://github.com/vector-im/vector-web/issues/348

`alwaysShowHeader` has been added to force the title to be shown even if there are 0 elements. Required so people can actually click the archived header.

`showSpinner` has been added to make a spinner spin if there are 0 elements. Required so people know a request is ongoing whilst getting archived rooms.

`onHeaderClick` has been added so we can call the JS SDK when the archived room header is clicked.

`startAsHidden` has been added to allow the initial collapsed/expanded state to be modified. Required because the archived section should be *collapsed* by default as we don't yet have the rooms until you try to expand it.

Also added a `TODO` questioning the naming of `props.collapsed` - it's terribly confusing because I think of collapsed as "no rooms are showing but you can expand them" but that is actually represented in the code as `state.hidden = true`.

See also:
 - https://github.com/matrix-org/matrix-js-sdk/pull/56
 - https://github.com/matrix-org/matrix-react-sdk/pull/62