### PR TITLE
Fixed call push notifications settings that always stayed OFF

### DIFF
--- a/src/components/views/settings/Notifications.js
+++ b/src/components/views/settings/Notifications.js
@@ -195,8 +195,8 @@ var VectorPushRulesDefinitions = {
             loud: [
                 "notify",
                 {
-                    "set_tweak": "ring",
-                    "value": "default"
+                    "set_tweak": "sound",
+                    "value": "ring"
                 }
             ]
         }


### PR DESCRIPTION
The bug was the bad declaration of .m.rule.call.