### PR TITLE
Always parse the hash of a URL as we do elsewhere

### DIFF
--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -94,7 +94,8 @@ function routeUrl(location) {
     else if (location.hash.indexOf('#/register') == 0) {
         window.matrixChat.showScreen('register', parseQsFromFragment(location));
     } else {
-        window.matrixChat.showScreen(location.hash.substring(2));
+        var hashparts = location.hash.split('?');
+        window.matrixChat.showScreen(hashparts[0].substring(2));
     }
 }
 


### PR DESCRIPTION
Always parse the hash of a URL as we do elsewhere by looking for a query string part, otherwise we end up passing the query into showscreen which then spreads havok.

Fixes https://github.com/vector-im/vector-web/issues/848