### PR TITLE
Make the README more idiot-proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,20 @@ Getting started
 ===============
 
 1. Install or update `node.js` so that your `npm` is at least at version `2.0.0`
-2. Clone the repo: `git clone https://github.com/vector-im/vector-web.git` 
-3. Switch to the SDK directory: `cd vector-web`
-4. Install the prerequisites: `npm install`
-5. Start the development builder and a testing server: `npm start`
-6. Wait a few seconds for the initial build to finish.
-7. Open http://127.0.0.1:8080/ in your browser to see your newly built Vector.
+1. Clone the repo: `git clone https://github.com/vector-im/vector-web.git` 
+1. Switch to the vector directory: `cd vector-web`
+1. Install the prerequisites: `npm install`
+1. Start the development builder and a testing server: `npm start`
+1. Wait a few seconds for the initial build to finish (the command won't
+   terminate: it's running a web server for you).
+1. Open http://127.0.0.1:8080/ in your browser to see your newly built Vector.
 
 With `npm start`, any changes you make to the source files will cause a rebuild so
 your changes will show up when you refresh. This development server also disables
 caching, so do NOT use it in production.
+
+Deployment
+==========
 
 For production use, run `npm run build` to build all the necessary files
 into the `vector` directory and run your own server.
@@ -29,9 +33,9 @@ setup above, and your changes will cause an instant rebuild.
 
 However, all serious development on Vector happens on the `develop` branch.  This typically
 depends on the `develop` snapshot versions of `matrix-react-sdk` and `matrix-js-sdk`
-too, which isn't handled by Vector's `package.json`.  To get the right dependencies, check out
-the `develop` branches of these libraries and then use `ln -s` to tell Vector
-about them:
+too, which can't be installed automatically due to https://github.com/npm/npm/issues/3055.
+To get the right dependencies, check out the `develop` branches of these libraries and
+then use `ln -s` to tell Vector about them:
 
 [Be aware that there may be problems with this process under npm version 3.]
 
@@ -41,17 +45,17 @@ First clone and build `matrix-js-sdk`:
 1. `pushd matrix-js-sdk`
 1. `git checkout develop`
 1. `npm install`
-1. `npm install source-map-loader` # because webpack is made of fail
+1. `npm install source-map-loader` # because webpack is made of fail (https://github.com/webpack/webpack/issues/1472)
 1. `popd`
 
 Then similarly with `matrix-react-sdk`:
 
 1. `git clone git@github.com:matrix-org/matrix-react-sdk.git`
-2. `pushd matrix-react-sdk`
-3. `git checkout develop`
-4. `npm install`
-5. `rm -r node_modules/matrix-js-sdk; ln -s ../../matrix-js-sdk node_modules/`
-6. `popd`
+1. `pushd matrix-react-sdk`
+1. `git checkout develop`
+1. `npm install`
+1. `rm -r node_modules/matrix-js-sdk; ln -s ../../matrix-js-sdk node_modules/`
+1. `popd`
 
 Finally, build and start vector itself:
 
@@ -75,6 +79,8 @@ Finally, build and start vector itself:
     bundle.css.map   116 kB       0  [emitted]  main
         + 1013 hidden modules
     ```
+   Remember, the command will not terminate since it runs the web server
+   and rebuilds source files when they change.
 1. Open http://127.0.0.1:8080/ in your browser to see your newly built Vector.
 
 When you make changes to `matrix-js-sdk` or `matrix-react-sdk`, you will need
@@ -84,12 +90,6 @@ builder which will watch for changes to the files and rebuild automatically.
 
 If you add or remove any components from the Vector skin, you will need to rebuild
 the skin's index by running, `npm run reskindex`.
-
-Deployment
-==========
-
-Just run `npm run build` and then mount the `vector` directory on your webserver to
-actually serve up the app, which is entirely static content.
 
 Enabling encryption
 ===================

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Deployment
 ==========
 
 For production use, run `npm run build` to build all the necessary files
-into the `vector` directory and run your own server.
+into the `vector` directory. You can then mount the vector directory on
+your webserver to actually serve up the app, which is entirely static content.
 
 Development
 ===========


### PR DESCRIPTION
 * Change to use auto-list numbering everywhere.
 * Move 'deployment' section up above development and removed duplicate information from 'Getting Started'
 * Clarify that `npm start` doesn't terminate
 * Reference the bugs that make our build process suck