### PR TITLE
Display room metadata from room previews when we come from the public room directory

### DIFF
--- a/src/components/structures/RoomDirectory.js
+++ b/src/components/structures/RoomDirectory.js
@@ -66,9 +66,27 @@ module.exports = React.createClass({
     },
 
     showRoom: function(roomId) {
+        var room;
+        for (var i = 0; i < this.state.publicRooms.length; ++i) {
+            if (this.state.publicRooms[i].room_id == roomId) {
+                room = this.state.publicRooms[i];
+                break;
+            }
+        }
+        var oob_data = {};
+        if (room) {
+            oob_data = {
+                avatarUrl: room.avatar_url,
+                // XXX: This logic is duplicated from the JS SDK which
+                // would normally decide what the name is.
+                name: room.name || room.aliases[0],
+            };
+        }
+
         dis.dispatch({
             action: 'view_room',
-            room_id: roomId
+            room_id: roomId,
+            oob_data: oob_data,
         });
     },
 

--- a/src/components/structures/RoomDirectory.js
+++ b/src/components/structures/RoomDirectory.js
@@ -66,6 +66,10 @@ module.exports = React.createClass({
     },
 
     showRoom: function(roomId) {
+        // extract the metadata from the publicRooms structure to pass
+        // as out-of-band data to view_room, because we get information
+        // here that we can't get other than by joining the room in some
+        // cases.
         var room;
         for (var i = 0; i < this.state.publicRooms.length; ++i) {
             if (this.state.publicRooms[i].room_id == roomId) {


### PR DESCRIPTION
(more hacks to work around the fact that we can't get this data from the HS)

Fixes https://github.com/vector-im/vector-web/issues/1016