### PR TITLE
Get and display a user's pushers in settings

### DIFF
--- a/src/components/views/settings/Notifications.js
+++ b/src/components/views/settings/Notifications.js
@@ -952,6 +952,8 @@ module.exports = React.createClass({
         } else if (this.state.pushers.length == 0) {
             devicesSection = <div><i>No devices are push notifications</i></div>
         } else {
+            // It would be great to be able to delete pushers from here too,
+            // and this wouldn't be hard to add.
             var rows = [];
             for (var i = 0; i < this.state.pushers.length; ++i) {
                 rows.push(<tr>

--- a/src/components/views/settings/Notifications.js
+++ b/src/components/views/settings/Notifications.js
@@ -950,7 +950,9 @@ module.exports = React.createClass({
         if (this.state.pushers === undefined) {
             devicesSection = <div className="error">Unable to fetch device list</div>
         } else if (this.state.pushers.length == 0) {
-            devicesSection = <div><i>No devices are push notifications</i></div>
+            devicesSection = <div className="mx_UserSettings_devicesTable_nodevices">
+                No devices are receiving push notifications
+            </div>
         } else {
             // It would be great to be able to delete pushers from here too,
             // and this wouldn't be hard to add.

--- a/src/skins/vector/css/vector-web/views/settings/Notifications.css
+++ b/src/skins/vector/css/vector-web/views/settings/Notifications.css
@@ -65,3 +65,6 @@ limitations under the License.
     padding-left: 20px;
     padding-right: 20px;
 }
+.mx_UserSettings_devicesTable_nodevices {
+    font-style: italic;
+}

--- a/src/skins/vector/css/vector-web/views/settings/Notifications.css
+++ b/src/skins/vector/css/vector-web/views/settings/Notifications.css
@@ -60,3 +60,8 @@ limitations under the License.
     cursor: pointer;
     color: #76cfa6;
 }
+
+.mx_UserSettings_devicesTable td {
+    padding-left: 20px;
+    padding-right: 20px;
+}


### PR DESCRIPTION
This is mostly groundwork for email notifications check box, but this makes it trivial to list the pushers on a user's account so adding this too because it could be a useful feature.

Requires https://github.com/matrix-org/synapse/pull/716 to work but will just display an error message on older servers.

Requires https://github.com/matrix-org/matrix-js-sdk/pull/125 (already merged).