### PR TITLE
Improve handling of notification rules we can't parse

### DIFF
--- a/src/notifications/VectorPushRulesDefinitions.js
+++ b/src/notifications/VectorPushRulesDefinitions.js
@@ -17,6 +17,46 @@ limitations under the License.
 'use strict';
 
 var StandardActions = require('./StandardActions');
+var PushRuleVectorState = require('./PushRuleVectorState');
+
+class VectorPushRuleDefinition {
+    constructor(opts) {
+        this.kind = opts.kind;
+        this.description = opts.description;
+        this.vectorStateToActions = opts.vectorStateToActions;
+    }
+
+    // Translate the rule actions and its enabled value into vector state
+    ruleToVectorState(rule) {
+        var enabled = false;
+        var actions = null;
+        if (rule) {
+            enabled = rule.enabled;
+            actions = rule.actions;
+        }
+
+        for (var stateKey in PushRuleVectorState.states) {
+            var state = PushRuleVectorState.states[stateKey];
+            var vectorStateToActions = this.vectorStateToActions[state];
+
+            if (!vectorStateToActions) {
+                // No defined actions means that this vector state expects a disabled (or absent) rule
+                if (!enabled) {
+                    return state;
+                }
+            } else {
+                // The actions must match to the ones expected by vector state
+                if (enabled && JSON.stringify(rule.actions) === JSON.stringify(vectorStateToActions)) {
+                    return state;
+                }
+            }
+        }
+
+        console.error("Cannot translate rule actions into Vector rule state. Rule: " +
+                      JSON.stringify(rule));
+        return undefined;
+    }
+};
 
 /**
  * The descriptions of rules managed by the Vector UI.
@@ -24,7 +64,7 @@ var StandardActions = require('./StandardActions');
 module.exports = {
     // Messages containing user's display name
     // (skip contains_user_name which is too geeky)
-    ".m.rule.contains_display_name": {
+    ".m.rule.contains_display_name": new VectorPushRuleDefinition({
         kind: "underride",
         description: "Messages containing my name",
         vectorStateToActions: { // The actions for each vector state, or null to disable the rule.
@@ -32,10 +72,10 @@ module.exports = {
             loud: StandardActions.ACTION_HIGHLIGHT_DEFAULT_SOUND,
             off: StandardActions.ACTION_DISABLED
         }
-    },
+    }),
 
     // Messages just sent to the user in a 1:1 room
-    ".m.rule.room_one_to_one": {
+    ".m.rule.room_one_to_one": new VectorPushRuleDefinition({
         kind: "underride",
         description: "Messages in one-to-one chats",
         vectorStateToActions: {
@@ -43,12 +83,12 @@ module.exports = {
             loud: StandardActions.ACTION_NOTIFY_DEFAULT_SOUND,
             off: StandardActions.ACTION_DONT_NOTIFY
         }
-    },
+    }),
 
     // Messages just sent to a group chat room
     // 1:1 room messages are catched by the .m.rule.room_one_to_one rule if any defined
     // By opposition, all other room messages are from group chat rooms.
-    ".m.rule.message": {
+    ".m.rule.message": new VectorPushRuleDefinition({
         kind: "underride",
         description: "Messages in group chats",
         vectorStateToActions: {
@@ -56,10 +96,10 @@ module.exports = {
             loud: StandardActions.ACTION_NOTIFY_DEFAULT_SOUND,
             off: StandardActions.ACTION_DONT_NOTIFY
         }
-    },
+    }),
 
     // Invitation for the user
-    ".m.rule.invite_for_me": {
+    ".m.rule.invite_for_me": new VectorPushRuleDefinition({
         kind: "underride",
         description: "When I'm invited to a room",
         vectorStateToActions: {
@@ -67,10 +107,10 @@ module.exports = {
             loud: StandardActions.ACTION_NOTIFY_DEFAULT_SOUND,
             off: StandardActions.ACTION_DISABLED
         }
-    },
+    }),
 
     // Incoming call
-    ".m.rule.call": {
+    ".m.rule.call": new VectorPushRuleDefinition({
         kind: "underride",
         description: "Call invitation",
         vectorStateToActions: {
@@ -78,10 +118,10 @@ module.exports = {
             loud: StandardActions.ACTION_NOTIFY_RING_SOUND,
             off: StandardActions.ACTION_DISABLED
         }
-    },
+    }),
 
     // Notifications from bots
-    ".m.rule.suppress_notices": {
+    ".m.rule.suppress_notices": new VectorPushRuleDefinition({
         kind: "override",
         description: "Messages sent by bot",
         vectorStateToActions: {
@@ -90,5 +130,5 @@ module.exports = {
             loud: StandardActions.ACTION_NOTIFY_DEFAULT_SOUND,
             off: StandardActions.ACTION_DONT_NOTIFY,
         }
-    }
+    }),
 };


### PR DESCRIPTION
* An absent rule is the same as a rule with 'enabled == false', and is not
necessarily 'OFF' (particularly in the case of the bot rule, which is
inverted).

* If we don't understand the rule, then don't tick any of the radio buttons,
and instead show it in the 'external' section.

Fixes https://github.com/vector-im/vector-web/issues/1348