### PR TITLE
Include react-addons-perf for non-production builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "parallelshell": "^1.2.0",
     "phantomjs-prebuilt": "^2.1.7",
     "react-addons-test-utils": "^15.0.1",
+    "react-addons-perf": "^15.0",
     "rimraf": "^2.4.3",
     "source-map-loader": "^0.1.5",
     "webpack": "^1.12.14"

--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -27,8 +27,15 @@ require('gemini-scrollbar/gemini-scrollbar.css');
 require('gfm.css/gfm.css');
 require('highlight.js/styles/github.css');
 
+
+ // add React and ReactPerf to the global namespace, to make them easier to
+ // access via the console
+global.React = require("react");
+if (process.env.NODE_ENV !== 'production') {
+    global.ReactPerf = require("react-addons-perf");
+}
+
 var RunModernizrTests = require("./modernizr"); // this side-effects a global
-var React = require("react");
 var ReactDOM = require("react-dom");
 var sdk = require("matrix-react-sdk");
 sdk.loadSkin(require('../component-index'));

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,6 +41,7 @@ module.exports = {
             // alias any requires to the react module to the one in our path, otherwise
             // we tend to get the react source included twice when using npm link.
             react: path.resolve('./node_modules/react'),
+            "react-addons-perf": path.resolve('./node_modules/react-addons-perf'),
 
             // same goes for js-sdk
             "matrix-js-sdk": path.resolve('./node_modules/matrix-js-sdk'),


### PR DESCRIPTION
This makes it possible to gather a few performance stats