### PR TITLE
Fix NPE when loading the Settings page which infini-spinnered

### DIFF
--- a/src/components/views/settings/Notifications.js
+++ b/src/components/views/settings/Notifications.js
@@ -74,6 +74,12 @@ module.exports = React.createClass({
         threepids: React.PropTypes.array.isRequired,
     },
 
+    getDefaultProps: function() {
+        return {
+            threepids: []
+        };
+    },
+
     getInitialState: function() {
         return {
             phase: this.phases.LOADING,


### PR DESCRIPTION
This line would NPE otherwise:
https://github.com/vector-im/vector-web/blob/8fb521c83c431542281f699708ddd864afb99f3e/src/components/views/settings/Notifications.js#L709