### PR TITLE
Build Vector in a Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Vector docker (A glossy Matrix collaboration client for the web)
+
+# use alpine base docker
+FROM alpine
+MAINTAINER ogarcia@connectical.com
+
+# update alpine and install necessary packages
+RUN apk -U --no-progress upgrade && \
+  apk -U --no-progress add nodejs git
+
+# add software to /vector
+COPY . /vector
+WORKDIR /vector
+
+# install prerequisites
+RUN npm install
+
+# configure container and run
+VOLUME ["/deploy"]
+ENTRYPOINT ["/bin/sh"]
+CMD ["docker/build.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,33 @@
+# Vector Docker builder
+
+The main purpose of this Docker image is build Vector web without install
+any dependency. This is useful in most production environments where you
+have fixed versions of packages.
+
+## Build Vector
+
+To build Vector simply run.
+
+```
+docker run -t -i --rm -v /host/dir/to/deploy:/deploy vector-im/vector-web
+```
+
+This command lets you a fresh build in `/host/dir/to/deploy` directory that
+you can use with you favorite web server.
+
+## Environment variables
+
+You can set some environment variables to Docker to modify `config.json`
+file. These are the following.
+
+* default_hs_url
+* default_is_url
+* brand
+* integrations_ui_url
+* integrations_rest_url
+
+Simply run Docker with `-e variable=value` as following sample.
+
+```
+docker run -t -i --rm -e default_hs_url=https://my.home.server.com -e brand='Vector Rocks!' -v /host/dir/to/deploy:/deploy vector-im/vector-web
+```

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,35 @@
+#! /bin/sh
+#
+# build.sh
+# Copyright (C) 2016 Óscar García Amor <ogarcia@connectical.com>
+#
+# Distributed under terms of the GNU GPLv3 license.
+#
+
+default_hs_url=${default_hs_url:-https://matrix.org}
+default_is_url=${default_is_url:-https://vector.im}
+brand=${brand:-Vector}
+integrations_ui_url=${integrations_ui_url:-http://localhost:8081}
+integrations_rest_url=${integrations_rest_url:-http://localhost:5050}
+
+# Make config file using environment vars
+cat > config.json << EOF
+{
+  "default_hs_url": "${default_hs_url}",
+  "default_is_url": "${default_is_url}",
+  "brand": "${brand}",
+  "integrations_ui_url": "${integrations_ui_url}",
+  "integrations_rest_url": "${integrations_rest_url}"
+}
+EOF
+
+# Build vector
+npm run build
+
+# Make deploy dir
+# This not is necessary if the user mount correctly the container volume,
+# but, Hey! THEY ARE USERS!!! ;D
+mkdir -p /deploy
+
+# Copy vector to deploy dir
+cp -Lr vector/* /deploy


### PR DESCRIPTION
This PR provides a Dockerfile and small script to build Vector Web in a Docker. It's useful if you cannot install node in your server.

This is thinked to run as "automagic" build in [Docker Hub](https://hub.docker.com/). I have "invented" the username / repo name in `README.md` file (`vector-im/vector-web`). Maybe you need adjust this.

I hope you like it. And ask me anything.

Greetings.