### PR TITLE
Karma: fix warning by ignoring olm

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -36,7 +36,7 @@ module.exports = function (config) {
         proxies: {
             "/img/": "/base/vector/img/",
         },
-        
+
         // preprocess matching files before serving them to the browser
         // available preprocessors:
         // https://npmjs.org/browse/keyword/karma-preprocessor
@@ -123,7 +123,7 @@ module.exports = function (config) {
 
                     // same goes for js-sdk
                     "matrix-js-sdk": path.resolve('./node_modules/matrix-js-sdk'),
-                    
+
                     sinon: 'sinon/pkg/sinon.js',
                 },
                 root: [
@@ -131,6 +131,11 @@ module.exports = function (config) {
                     path.resolve('./test'),
                 ],
             },
+            plugins: [
+                // olm may not be installed, so avoid webpack warnings by
+                // ignoring it.
+                new webpack.IgnorePlugin(/^olm$/),
+            ],
             devtool: 'inline-source-map',
         },
     });


### PR DESCRIPTION
If olm is not installed, the webpack build for the karma tests gives an ugly
error. None of the tests currently care if olm is installed or not, so fix this
for now by just ignoring the olm module.