### PR TITLE
CSS fix for rooms with crypto enabled

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/views/rooms/EventTile.css
+++ b/src/skins/vector/css/matrix-react-sdk/views/rooms/EventTile.css
@@ -17,7 +17,7 @@ limitations under the License.
 .mx_EventTile {
     max-width: 100%;
     clear: both;
-    margin-top: 24px;
+    padding-top: 24px;
     margin-left: 65px;
 }
 
@@ -33,7 +33,7 @@ limitations under the License.
 }
 
 .mx_EventTile_continuation {
-    margin-top: 8px ! important;
+    padding-top: 8px ! important;
 }
 
 .mx_EventTile_verified {


### PR DESCRIPTION
When encryption is enabled, we (currently) highlight messages from validated
senders in green, and encrypted messages from unvalidated senders in red.

This is a fix from matthew to "make it look less like fanfold printer paper".