### PR TITLE
#1664 Set a maximum height for codeblocks

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/views/messages/MTextBody.css
+++ b/src/skins/vector/css/matrix-react-sdk/views/messages/MTextBody.css
@@ -17,3 +17,8 @@ limitations under the License.
 .mx_MTextBody {
     white-space: pre-wrap;
 }
+
+.mx_MTextBody pre{
+  overflow-y: auto;
+  max-height: 30vh;
+}


### PR DESCRIPTION
I found 30 to be a nice maximum size since you have a nice size window, but it won't take up the whole chat.