### PR TITLE
webpack: always use the olm from vector-web

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,6 +43,10 @@ module.exports = {
 
             // same goes for js-sdk
             "matrix-js-sdk": path.resolve('./node_modules/matrix-js-sdk'),
+
+            // make sure we use the version of olm from vector-web rather than
+            // js-sdk.
+            "olm": path.resolve('./node_modules/olm'),
         },
     },
     plugins: [


### PR DESCRIPTION
Fixes an error when matrix-js-sdk is symlinked into node_modules, which meant
that we would (try to) use the version of olm from js-sdk instead of
vector-web (https://github.com/vector-im/vector-web/issues/1765).