### PR TITLE
Wmwragg/modal restyle

### DIFF
--- a/src/skins/vector/css/common.css
+++ b/src/skins/vector/css/common.css
@@ -161,8 +161,8 @@ input[type=text]:focus, textarea:focus {
     left: 0;
     width: 100%;
     height: 100%;
-    background-color: #000;
-    opacity: 0.2;
+    background-color: #e9e9e9;
+    opacity: 0.8;
 }
 
 .mx_Dialog_lightbox .mx_Dialog_background {

--- a/src/skins/vector/css/common.css
+++ b/src/skins/vector/css/common.css
@@ -173,6 +173,7 @@ input[type=text]:focus, textarea:focus {
 
 .mx_Dialog_lightbox .mx_Dialog_background {
     opacity: 0.85;
+    background-color: #000;
 }
 
 .mx_Dialog_lightbox .mx_Dialog {

--- a/src/skins/vector/css/common.css
+++ b/src/skins/vector/css/common.css
@@ -213,7 +213,7 @@ input[type=text]:focus, textarea:focus {
     background-color: #fff;
 }
 
-.mx_Dialog .mx_Dialog_primary {
+.mx_Dialog button.mx_Dialog_primary, .mx_Dialog  input[type="submit"].mx_Dialog_primary {
     color: #fff;
     background-color: #76cfa6;
 }

--- a/src/skins/vector/css/common.css
+++ b/src/skins/vector/css/common.css
@@ -146,13 +146,14 @@ input[type=text]:focus, textarea:focus {
 .mx_Dialog {
     background-color: #fff;
     color: #747474;
-    text-align: center;
     z-index: 4010;
     font-weight: 300;
     font-size: 15px;
     position: relative;
-    border-radius: 8px;
-    max-width: 80%;
+    padding-left: 58px;
+    width: 60%;
+    max-width: 704px;
+    box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.2);
 }
 
 .mx_Dialog_background {
@@ -180,11 +181,14 @@ input[type=text]:focus, textarea:focus {
 }
 
 .mx_Dialog_content {
-    margin: 24px;
+    margin: 24px 58px 68px 0;
+    font-size: 14px;
+	color: #4a4a4a;
+    word-wrap: break-word;
 }
 
 .mx_Dialog_buttons {
-    padding-bottom: 24px;
+    padding-bottom: 36px;
 }
 
 .mx_Dialog button, .mx_Dialog input[type="submit"] {
@@ -195,19 +199,20 @@ input[type=text]:focus, textarea:focus {
     font-size: 15px;
     color: #fff;
     background-color: #76cfa6;
-    margin-left: 8px;
+    margin-left: 0px;
     margin-right: 8px;
-    padding-left: 1em;
-    padding-right: 1em;
+    padding-left: 1.5em;
+    padding-right: 1.5em;
+    outline: none;
 }
 
 .mx_Dialog_title {
     min-height: 16px;
-    padding: 12px;
-    border-bottom: 1px solid #a4a4a4;
+    padding-top: 40px;
     font-weight: bold;
-    font-size: 18px;
+    font-size: 22px;
     line-height: 1.4;
+    color: #454545;
 }
 
 .mx_TextInputDialog_label {

--- a/src/skins/vector/css/common.css
+++ b/src/skins/vector/css/common.css
@@ -58,6 +58,11 @@ input[type=text]:focus, textarea:focus {
     box-shadow: none;
 }
 
+/* Prevent ugly dotted highlight around selected elements in Firefox */
+::-moz-focus-inner {
+    border: 0;
+}
+
 /* applied to side-panels and messagepanel when in RoomSettings */
 .mx_fadable {
     opacity: 1;
@@ -202,28 +207,15 @@ input[type=text]:focus, textarea:focus {
     margin-right: 8px;
     padding-left: 1.5em;
     padding-right: 1.5em;
+    outline: none;
 
     color: #76cfa6;
     background-color: #fff;
-    outline: none;
 }
 
-/* The first button in a dialog is the primary */
-.mx_Dialog button:first-child, .mx_Dialog input[type="submit"]:first-child {
-    border: 0px;
-    height: 36px;
-    border-radius: 40px;
-    border: solid 1px #76cfa6;
-    font-weight: 400;
-    font-size: 15px;
-    margin-left: 0px;
-    margin-right: 8px;
-    padding-left: 1.5em;
-    padding-right: 1.5em;
-
+.mx_Dialog .mx_Dialog_primary {
     color: #fff;
     background-color: #76cfa6;
-    outline: none;
 }
 
 .mx_Dialog_title {

--- a/src/skins/vector/css/common.css
+++ b/src/skins/vector/css/common.css
@@ -194,15 +194,35 @@ input[type=text]:focus, textarea:focus {
 .mx_Dialog button, .mx_Dialog input[type="submit"] {
     border: 0px;
     height: 36px;
-    border-radius: 36px;
+    border-radius: 40px;
+    border: solid 1px #76cfa6;
     font-weight: 400;
     font-size: 15px;
-    color: #fff;
-    background-color: #76cfa6;
     margin-left: 0px;
     margin-right: 8px;
     padding-left: 1.5em;
     padding-right: 1.5em;
+
+    color: #76cfa6;
+    background-color: #fff;
+    outline: none;
+}
+
+/* The first button in a dialog is the primary */
+.mx_Dialog button:first-child, .mx_Dialog input[type="submit"]:first-child {
+    border: 0px;
+    height: 36px;
+    border-radius: 40px;
+    border: solid 1px #76cfa6;
+    font-weight: 400;
+    font-size: 15px;
+    margin-left: 0px;
+    margin-right: 8px;
+    padding-left: 1.5em;
+    padding-right: 1.5em;
+
+    color: #fff;
+    background-color: #76cfa6;
     outline: none;
 }
 


### PR DESCRIPTION
Restyles the Modal dialog boxes as shown in Zeplin "02_x Chat modal" and closes #1760. There is a linked branch `wmwragg/modal-restyle` on the `matrix-react-sdk` repo that also needs to be merged.

Signed-off-by: William Wragg <wm.wragg@gmail.com>  