### PR TITLE
Make sure that we clear localstorage before *all* tests

### DIFF
--- a/test/app-tests/loading.js
+++ b/test/app-tests/loading.js
@@ -59,8 +59,6 @@ describe('loading:', function () {
 
         windowLocation = null;
         matrixChat = null;
-
-        window.localStorage.clear();
     });
 
     afterEach(function() {

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -12,6 +12,10 @@ module.exports.beforeEach = function(context) {
     console.log();
     console.log(desc);
     console.log(new Array(1 + desc.length).join("="));
+
+    // some tests store things in localstorage. Improve independence of tests
+    // by making sure that they don't inherit any old state.
+    window.localStorage.clear();
 };
 
 /**


### PR DESCRIPTION
This was causing flaky tests, as sometimes the joining test would inherit an
"mx_is_guest" setting from a previous test run.