### PR TITLE
Don't show border on composer when not in RTE mode

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/views/rooms/MessageComposer.css
+++ b/src/skins/vector/css/matrix-react-sdk/views/rooms/MessageComposer.css
@@ -62,8 +62,6 @@ limitations under the License.
     display: flex;
     align-items: center;
     overflow: auto;
-    transition: 0.6s border-top ease;
-    border-top: 2px solid rgba(255, 255, 255, 0);
 }
 .mx_MessageComposer_input_rte {
     border-top: 2px solid #76cfa6; /* placeholder RTE indicator */


### PR DESCRIPTION
This breaks the opacity animation (so remove the transition) but the extra border was making the border on the composer too thick.