### PR TITLE
Added event/info message avatars back in

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/views/rooms/EventTile.css
+++ b/src/skins/vector/css/matrix-react-sdk/views/rooms/EventTile.css
@@ -34,6 +34,11 @@ limitations under the License.
     z-index: 2;
 }
 
+.mx_EventTile.mx_EventTile_info .mx_EventTile_avatar {
+    top: 8px;
+    left: 44px;
+}
+
 .mx_EventTile_continuation {
     padding-top: 0px ! important;
 }


### PR DESCRIPTION
This adds back avatars for the event messages restyled in #1748. A companion branch matrix-org/matrix-react-sdk:wmwragg/chat-message-presentation also needs to be merged.

Signed-off-by: William Wragg wm.wragg@gmail.com