### PR TITLE
Turn react consistency checks back on in develop builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:css": "catw \"src/skins/vector/css/**/*.css\" -o vector/components.css --no-watch",
     "build:compile": "babel --source-maps -d lib src",
     "build:bundle": "NODE_ENV=production webpack -p lib/vector/index.js vector/bundle.js",
-    "build:bundle:dev": "NODE_ENV=production webpack --optimize-occurence-order lib/vector/index.js vector/bundle.js",
+    "build:bundle:dev": "webpack --optimize-occurence-order lib/vector/index.js vector/bundle.js",
     "build:staticfiles": "cpx -v node_modules/olm/olm.js vector/",
     "build": "npm run build:staticfiles && npm run build:emojione && npm run build:css && npm run build:compile && npm run build:bundle",
     "build:dev": "npm run build:staticfiles && npm run build:emojione && npm run build:css && npm run build:compile && npm run build:bundle:dev",


### PR DESCRIPTION
The react checks are useful on /develop, to catch programming errors earlier,
and the original reason for turning them off (so that we could meaningfully
compare performance between /develop and /beta) is no longer so
relevant.

This reverts commit b5f029d10e8a3b7a0d03cc65504de00ac0c4d1f4.