### PR TITLE
Improve readability of the changelog dialog

### DIFF
--- a/src/components/views/dialogs/ChangelogDialog.js
+++ b/src/components/views/dialogs/ChangelogDialog.js
@@ -50,9 +50,11 @@ export default class ChangelogDialog extends React.Component {
             return (
                 <div key={repo}>
                     <h2>{repo}</h2>
+                    <ul>
                     {this.state[repo].map(commit =>
-                        <div key={commit.commit.url}><a href={commit.commit.url}>{commit.commit.message}</a></div>
+                        <li key={commit.commit.url} className="mx_ChangelogDialog_li"><a href={commit.commit.url}>{commit.commit.message}</a></li>
                     )}
+                    </ul>
                 </div>
             )
         });

--- a/src/skins/vector/css/vector-web/views/dialogs/ChangelogDialog.css
+++ b/src/skins/vector/css/vector-web/views/dialogs/ChangelogDialog.css
@@ -18,3 +18,7 @@ limitations under the License.
     max-height: 300px;
     overflow: auto;
 }
+
+.mx_ChangelogDialog_li {
+    padding: 0.2em;
+}


### PR DESCRIPTION
This makes it easier to distinguish multiline commit messages from separate commits