### PR TITLE
jenkins.sh: install olm from jenkins artifacts

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -13,6 +13,9 @@ npm install
 # apparently npm 3.10.3 on node 6.4.0 doesn't upgrade #develop target with npm install unless explicitly asked.
 npm install matrix-react-sdk matrix-js-sdk
 
+# install olm
+npm install ./olm/olm-*.tgz
+
 # we may be using a dev branch of react-sdk, in which case we need to build it
 (cd node_modules/matrix-react-sdk && npm run build)
 


### PR DESCRIPTION
Use the latest version of olm, as provided by jenkins, rather than the most
recent release.