### PR TITLE
Add native joining of 3p networks to room dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,32 @@ You can configure the app by copying `vector/config.sample.json` to
    addresses) to matrix IDs: see http://matrix.org/docs/spec/identity_service/unstable.html
    for more details.  Currently the only public matrix identity servers are https://matrix.org
    and https://vector.im.  In future identity servers will be decentralised.
-
+1. `roomDirectory`: config for the public room directory. This section encodes behaviour
+   on the room directory screen for filtering the list by server / network type and joining
+   third party networks. This config section will disappear once APIs are available to
+   get this information for home servers. This section is optional.
+1. `roomDirectory.servers`: List of other Home Servers' directories to include in the drop
+   down list. Optional.
+1. `roomDirectory.serverConfig`: Config for each server in `roomDirectory.servers`. Optional.
+1. `roomDirectory.serverConfig.<server_name>.networks`: List of networks (named
+   in `roomDirectory.networks`) to include for this server. Optional.
+1. `roomDirectory.networks`: config for each network type. Optional.
+1. `roomDirectory.<network_type>.name`: Human-readable name for the network. Required.
+1. `roomDirectory.<network_type>.protocol`: Protocol as given by the server in
+   `/_matrix/client/unstable/thirdparty/protocolss` response. Required to be able to join
+   this type of third party network.
+1. `roomDirectory.<network_type>.domain`: Domain as given by the server in
+   `/_matrix/client/unstable/thirdparty/protocols` response, if present. Required to be
+   able to join this type of third party network, if present in `thirdparty/protocols`.
+1. `roomDirectory.<network_type>.portalRoomPattern`: Regular expression matching aliases
+   for portal rooms to locations on this network. Required.
+1. `roomDirectory.<network_type>.icon`: URL to an icon to be displayed for this network. Required.
+1. `roomDirectory.<network_type>.example`: Textual example of a location on this network,
+   eg. '#channel' for an IRC network. Optional.
+1. `roomDirectory.<network_type>.nativePattern`: Regular expression that matches a
+   valid location on this network. This is used as a hint to the user to indicate
+   when a valid location has been entered so it's not necessary for this to be
+   exactly correct. Optional.
 
 Running as a Desktop app
 ========================

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ You can configure the app by copying `vector/config.sample.json` to
 1. `roomDirectory.networks`: config for each network type. Optional.
 1. `roomDirectory.<network_type>.name`: Human-readable name for the network. Required.
 1. `roomDirectory.<network_type>.protocol`: Protocol as given by the server in
-   `/_matrix/client/unstable/thirdparty/protocolss` response. Required to be able to join
+   `/_matrix/client/unstable/thirdparty/protocols` response. Required to be able to join
    this type of third party network.
 1. `roomDirectory.<network_type>.domain`: Domain as given by the server in
    `/_matrix/client/unstable/thirdparty/protocols` response, if present. Required to be

--- a/src/components/structures/RoomDirectory.js
+++ b/src/components/structures/RoomDirectory.js
@@ -64,11 +64,12 @@ module.exports = React.createClass({
         this.nativePatterns = {};
         if (this.props.config.networks) {
             for (const network of Object.keys(this.props.config.networks)) {
-                if (this.props.config.networks[network].portalRoomPattern) {
-                    this.portalRoomPatterns[network] = new RegExp(this.props.config.networks[network].portalRoomPattern);
+                const network_info = this.props.config.networks[network];
+                if (network_info.portalRoomPattern) {
+                    this.portalRoomPatterns[network] = new RegExp(network_info.portalRoomPattern);
                 }
-                if (this.props.config.networks[network].nativePattern) {
-                    this.nativePatterns[network] = new RegExp(this.props.config.networks[network].nativePattern);
+                if (network_info.nativePattern) {
+                    this.nativePatterns[network] = new RegExp(network_info.nativePattern);
                 }
             }
         }

--- a/src/components/structures/RoomDirectory.js
+++ b/src/components/structures/RoomDirectory.js
@@ -132,7 +132,7 @@ module.exports = React.createClass({
             opts.server = my_server;
         }
         if (this.nextBatch) opts.since = this.nextBatch;
-        if (this.state.filterString) opts.filter = { generic_search_term: my_filter_string } ;
+        if (my_filter_string) opts.filter = { generic_search_term: my_filter_string } ;
         return MatrixClientPeg.get().publicRooms(opts).then((data) => {
             if (
                 my_filter_string != this.state.filterString ||
@@ -498,7 +498,7 @@ module.exports = React.createClass({
 
         if (!this.protocols) return null;
 
-        let instance;
+        let matched_instance;
         // Try to find which instance in the 'protocols' response
         // matches this network. We look for a matching protocol
         // and the existence of a 'domain' field and if present,
@@ -509,18 +509,18 @@ module.exports = React.createClass({
             // as long as it has no domain (which we assume to mean it's
             // there is only one possible instance).
             if (the_instance.fields.domain === undefined && network_info.domain === undefined) {
-                instance = this.protocols[network_info.protocol].instances[0];
+                matched_instance = this.protocols[network_info.protocol].instances[0];
             }
         } else if (network_info.domain) {
             // otherwise, we look for one with a matching domain.
             for (const this_instance of this.protocols[network_info.protocol].instances) {
                 if (this_instance.fields.domain == network_info.domain) {
-                    instance = this_instance;
+                    matched_instance = this_instance;
                 }
             }
         }
 
-        if (instance === undefined) return null;
+        if (matched_instance === undefined) return null;
 
         // now make an object with the fields specified by that protocol. We
         // require that the values of all but the last field come from the
@@ -529,8 +529,8 @@ module.exports = React.createClass({
         const fields = {};
         for (let i = 0; i < required_fields.length - 1; ++i) {
             const this_field = required_fields[i];
-            if (instance.fields[this_field] === undefined) return null;
-            fields[this_field] = instance.fields[this_field];
+            if (matched_instance.fields[this_field] === undefined) return null;
+            fields[this_field] = matched_instance.fields[this_field];
         }
         fields[required_fields[required_fields.length - 1]] = user_input;
         return fields;

--- a/src/components/structures/RoomDirectory.js
+++ b/src/components/structures/RoomDirectory.js
@@ -509,7 +509,7 @@ module.exports = React.createClass({
             // as long as it has no domain (which we assume to mean it's
             // there is only one possible instance).
             if (the_instance.fields.domain === undefined && network_info.domain === undefined) {
-                matched_instance = this.protocols[network_info.protocol].instances[0];
+                matched_instance = the_instance;
             }
         } else if (network_info.domain) {
             // otherwise, we look for one with a matching domain.

--- a/src/components/structures/RoomDirectory.js
+++ b/src/components/structures/RoomDirectory.js
@@ -82,6 +82,12 @@ module.exports = React.createClass({
         MatrixClientPeg.get().getThirdpartyProtocols().done((response) => {
             this.protocols = response;
         }, (err) => {
+            if (MatrixClientPeg.get().isGuest()) {
+                // Guests currently aren't allowed to use this API, so
+                // ignore this as otherwise this error is literally the
+                // thing you see when loading the client!
+                return;
+            }
             const ErrorDialog = sdk.getComponent("dialogs.ErrorDialog");
             Modal.createDialog(ErrorDialog, {
                 title: "Failed to get protocol list from Home Server",

--- a/src/components/structures/RoomDirectory.js
+++ b/src/components/structures/RoomDirectory.js
@@ -508,7 +508,16 @@ module.exports = React.createClass({
             // If there's only one instance in this protocol, use it
             // as long as it has no domain (which we assume to mean it's
             // there is only one possible instance).
-            if (the_instance.fields.domain === undefined && network_info.domain === undefined) {
+            if (
+                (
+                    the_instance.fields.domain === undefined &&
+                    network_info.domain === undefined
+                ) ||
+                (
+                    the_instance.fields.domain !== undefined &&
+                    the_instance.fields.domain == network_info.domain
+                )
+            ) {
                 matched_instance = the_instance;
             }
         } else if (network_info.domain) {

--- a/src/components/views/directory/NetworkDropdown.js
+++ b/src/components/views/directory/NetworkDropdown.js
@@ -170,17 +170,18 @@ export default class NetworkDropdown extends React.Component {
             icon = <img src="img/network-matrix.svg" width="16" height="16" />;
             span_class = 'mx_NetworkDropdown_menu_network';
         } else {
-            if (this.props.config.networks[network]) {
-                if (this.props.config.networks[network].name) {
-                    name = this.props.config.networks[network].name;
-                } else {
-                    name = network;
-                }
-                if (this.props.config.networks[network].icon) {
-                    icon = <img src={this.props.config.networks[network].icon} />;
-                } else {
-                    icon = <img src={iconPath} width="16" height="16" />;
-                }
+            if (this.props.config.networks[network] === undefined) {
+                throw new Error(network + ' network missing from config');
+            }
+            if (this.props.config.networks[network].name) {
+                name = this.props.config.networks[network].name;
+            } else {
+                name = network;
+            }
+            if (this.props.config.networks[network].icon) {
+                icon = <img src={this.props.config.networks[network].icon} />;
+            } else {
+                icon = <img src={iconPath} width="16" height="16" />;
             }
 
             span_class = 'mx_NetworkDropdown_menu_network';
@@ -210,7 +211,7 @@ export default class NetworkDropdown extends React.Component {
             </div>;
             current_value = <input type="text" className="mx_NetworkDropdown_networkoption"
                 ref={this.collectInputTextBox} onKeyUp={this.onInputKeyUp}
-                placeholder="matrix.org"
+                placeholder="matrix.org" // 'matrix.org' as an example of an HS name
             />
         } else {
             current_value = this._makeMenuOption(

--- a/src/components/views/directory/NetworkDropdown.js
+++ b/src/components/views/directory/NetworkDropdown.js
@@ -40,7 +40,7 @@ export default class NetworkDropdown extends React.Component {
             this.props.config.serverConfig &&
             this.props.config.serverConfig[server] &&
             this.props.config.serverConfig[server].networks &&
-            '_matrix' in this.props.config.serverConfig[server].networks
+            this.props.config.serverConfig[server].networks.indexOf('_matrix') > -1
         ) {
             defaultNetwork = '_matrix';
         }
@@ -170,8 +170,19 @@ export default class NetworkDropdown extends React.Component {
             icon = <img src="img/network-matrix.svg" width="16" height="16" />;
             span_class = 'mx_NetworkDropdown_menu_network';
         } else {
-            name = this.props.config.networkNames[network];
-            icon = <img src={this.props.config.networkIcons[network]} />;
+            if (this.props.config.networks[network]) {
+                if (this.props.config.networks[network].name) {
+                    name = this.props.config.networks[network].name;
+                } else {
+                    name = network;
+                }
+                if (this.props.config.networks[network].icon) {
+                    icon = <img src={this.props.config.networks[network].icon} />;
+                } else {
+                    icon = <img src={iconPath} width="16" height="16" />;
+                }
+            }
+
             span_class = 'mx_NetworkDropdown_menu_network';
         }
 
@@ -199,6 +210,7 @@ export default class NetworkDropdown extends React.Component {
             </div>;
             current_value = <input type="text" className="mx_NetworkDropdown_networkoption"
                 ref={this.collectInputTextBox} onKeyUp={this.onInputKeyUp}
+                placeholder="matrix.org"
             />
         } else {
             current_value = this._makeMenuOption(

--- a/src/components/views/directory/NetworkDropdown.js
+++ b/src/components/views/directory/NetworkDropdown.js
@@ -179,7 +179,9 @@ export default class NetworkDropdown extends React.Component {
                 name = network;
             }
             if (this.props.config.networks[network].icon) {
-                icon = <img src={this.props.config.networks[network].icon} />;
+                // omit height here so if people define a non-square logo in the config, it
+                // will keep the aspect when it scales
+                icon = <img src={this.props.config.networks[network].icon} width="16" />;
             } else {
                 icon = <img src={iconPath} width="16" height="16" />;
             }

--- a/vector/config.sample.json
+++ b/vector/config.sample.json
@@ -15,24 +15,53 @@
                     "_matrix",
                     "gitter",
                     "irc:freenode",
-                    "irc:mozilla"
+                    "irc:mozilla",
+                    "irc:snoonet",
+                    "irc:oftc"
                 ]
             }
         },
-        "networkPatterns": {
-            "gitter": "#gitter_.*:matrix.org",
-            "irc:freenode": "#freenode_.*:matrix.org",
-            "irc:mozilla": "#mozilla_.*:matrix.org"
-        },
-        "networkNames": {
-            "irc:freenode": "Freenode",
-            "irc:mozilla": "Mozilla",
-            "gitter": "Gitter"
-        },
-        "networkIcons": {
-            "irc:freenode": "//matrix.org/_matrix/media/v1/download/matrix.org/DHLHpDDgWNNejFmrewvwEAHX",
-            "irc:mozilla": "//matrix.org/_matrix/media/v1/download/matrix.org/DHLHpDDgWNNejFmrewvwEAHX",
-            "gitter": "//gitter.im/favicon.ico"
+        "networks": {
+            "gitter": {
+                "protocol": "gitter",
+                "portalRoomPattern": "#gitter_.*:matrix.org",
+                "name": "Gitter",
+                "icon": "//gitter.im/favicon.ico",
+                "example": "org/community",
+                "nativePattern": "[^\\s]+/[^\\s]+$"
+            },
+            "irc:freenode": {
+                "portalRoomPattern": "#freenode_.*:matrix.org",
+                "name": "Freenode",
+                "icon": "//matrix.org/_matrix/media/v1/download/matrix.org/DHLHpDDgWNNejFmrewvwEAHX",
+                "example": "#channel",
+                "nativePattern": "^#[^\\s]+$"
+            },
+            "irc:mozilla": {
+                "portalRoomPattern": "#mozilla_.*:matrix.org",
+                "name": "Mozilla",
+                "icon": "//matrix.org/_matrix/media/v1/download/matrix.org/DHLHpDDgWNNejFmrewvwEAHX",
+                "example": "#channel",
+                "nativePattern": "^#[^\\s]+$"
+            },
+            "irc:snoonet": {
+                "protocol": "irc",
+                "domain": "ipv6-irc.snoonet.org",
+                "portalRoomPattern": "#_snoonet_.*:matrix.org",
+                "name": "Snoonet",
+                "icon": "//matrix.org/_matrix/media/v1/download/matrix.org/DHLHpDDgWNNejFmrewvwEAHX",
+                "example": "#channel",
+                "nativePattern": "^#[^\\s]+$"
+            },
+            "irc:oftc": {
+                "protocol": "irc",
+                "domain": "irc.oftc.net",
+                "portalRoomPattern": "#_oftc_.*:matrix.org",
+                "name": "OFTC",
+                "icon": "//matrix.org/_matrix/media/v1/download/matrix.org/DHLHpDDgWNNejFmrewvwEAHX",
+                "example": "#channel",
+                "nativePattern": "^#[^\\s]+$"
+            }
         }
     }
 }


### PR DESCRIPTION
Use the 3rd party location lookup API to accept third-party locations
in their native form and look up the corresponding portal room for
that location.

Also give the network dropdown some placeholder text.

Fixes https://github.com/vector-im/vector-web/issues/2374
Requires https://github.com/matrix-org/matrix-react-sdk/pull/502
Requires https://github.com/matrix-org/matrix-js-sdk/pull/217