### PR TITLE
Correct text alignment on room directory search

### DIFF
--- a/src/skins/vector/css/vector-web/structures/RoomDirectory.css
+++ b/src/skins/vector/css/vector-web/structures/RoomDirectory.css
@@ -62,6 +62,7 @@ limitations under the License.
 
 .mx_RoomDirectory_searchbox {
     display: table-cell;
+    vertical-align: middle;
 }
 
 .mx_RoomDirectory_listheader .mx_NetworkDropdown {


### PR DESCRIPTION
Seemed to only be broken on firefox