### PR TITLE
Avoid errors if olm is missing

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -102,3 +102,12 @@ module.exports = {
     ],
     devtool: 'source-map'
 };
+
+// olm is an optional dependency. Ignore it if it's not installed, to avoid a
+// scary-looking error.
+try {
+    require('olm');
+} catch (e) {
+    console.log("Olm is not installed; not shipping it");
+    delete(module.exports.entry["olm"]);
+}


### PR DESCRIPTION
If olm isn't installed, webpack prints out scary warnings (though it still
actually succeeds). Let's avoid scaring people by quietly removing it from the
list of things to process.