### PR TITLE
Move 'new version' support into Platform

### DIFF
--- a/src/components/views/globals/NewVersionBar.js
+++ b/src/components/views/globals/NewVersionBar.js
@@ -37,18 +37,6 @@ export default React.createClass({
         releaseNotes: React.PropTypes.string,
     },
 
-    onChangelogClicked: function() {
-        // If we have release notes to display, we display them. Otherwise,
-        // we display the Changelog Dialog which takes two versions and
-        // automatically tells you what's changed (provided the versions
-        // are in the right format)
-        if (this.props.releaseNotes) {
-            this.displayReleaseNotes(this.props.releaseNotes);
-        } else if (checkVersion(this.props.version) && checkVersion(this.props.newVersion)) {
-            this.displayChangelog();
-        }
-    },
-
     displayReleaseNotes: function(releaseNotes) {
         const QuestionDialog = sdk.getComponent('dialogs.QuestionDialog');
         Modal.createDialog(QuestionDialog, {
@@ -82,8 +70,14 @@ export default React.createClass({
 
     render: function() {
         let action_button;
-        if (this.props.releaseNotes || (checkVersion(this.props.version) && checkVersion(this.props.newVersion))) {
-            action_button = <button className="mx_MatrixToolbar_action" onClick={this.onChangelogClicked}>What's new?</button>;
+        // If we have release notes to display, we display them. Otherwise,
+        // we display the Changelog Dialog which takes two versions and
+        // automatically tells you what's changed (provided the versions
+        // are in the right format)
+        if (this.props.releaseNotes) {
+            action_button = <button className="mx_MatrixToolbar_action" onClick={this.displayReleaseNotes}>What's new?</button>;
+        } else if (checkVersion(this.props.version) && checkVersion(this.props.newVersion)) {
+            action_button = <button className="mx_MatrixToolbar_action" onClick={this.displayChangelog}>What's new?</button>;
         } else if (PlatformPeg.get()) {
             action_button = <button className="mx_MatrixToolbar_action" onClick={this.onUpdateClicked}>Update</button>;
         }

--- a/src/skins/vector/css/common.css
+++ b/src/skins/vector/css/common.css
@@ -288,3 +288,7 @@ textarea {
     cursor: pointer;
     display: inline;
 }
+
+.changelog_text {
+    font-family: 'Open Sans', Arial, Helvetica, Sans-Serif;
+}

--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -113,10 +113,6 @@ function onHashChange(ev) {
     routeUrl(window.location);
 }
 
-function onVersion(current, latest) {
-    window.matrixChat.onVersion(current, latest);
-}
-
 var loaded = false;
 var lastLoadedScreen = null;
 
@@ -165,8 +161,7 @@ window.onload = function() {
     if (!validBrowser) {
         return;
     }
-    UpdateChecker.setVersionListener(onVersion);
-    UpdateChecker.run();
+    UpdateChecker.start();
     routeUrl(window.location);
     loaded = true;
     if (lastLoadedScreen) {

--- a/src/vector/platform/VectorBasePlatform.js
+++ b/src/vector/platform/VectorBasePlatform.js
@@ -1,0 +1,41 @@
+// @flow
+
+/*
+Copyright 2016 Aviral Dasgupta and OpenMarket Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import BasePlatform from 'matrix-react-sdk/lib/BasePlatform'
+
+/**
+ * Vector-specific extensions to the BasePlatform template
+ */
+export default class VectorBasePlatform extends BasePlatform {
+    /**
+     * Check for the availability of an update to the version of the
+     * app that's currently running.
+     * If an update is available, this function should dispatch the
+     * 'new_version' action.
+     */
+    pollForUpdate() {
+    }
+
+    /**
+     * Update the currently running app to the latest available
+     * version and replace this instance of the app with the
+     * new version.
+     */
+    installUpdate() {
+    }
+}

--- a/src/vector/platform/VectorBasePlatform.js
+++ b/src/vector/platform/VectorBasePlatform.js
@@ -1,7 +1,8 @@
 // @flow
 
 /*
-Copyright 2016 Aviral Dasgupta and OpenMarket Ltd
+Copyright 2016 Aviral Dasgupta
+Copyright 2016 OpenMarket Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/vector/platform/WebPlatform.js
+++ b/src/vector/platform/WebPlatform.js
@@ -16,13 +16,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import BasePlatform from 'matrix-react-sdk/lib/BasePlatform';
+import VectorBasePlatform from './VectorBasePlatform';
 import Favico from 'favico.js';
 import request from 'browser-request';
 import dis from 'matrix-react-sdk/lib/dispatcher.js';
 import q from 'q';
 
-export default class WebPlatform extends BasePlatform {
+export default class WebPlatform extends VectorBasePlatform {
     constructor() {
         super();
         this.runningVersion = null;

--- a/src/vector/updater.js
+++ b/src/vector/updater.js
@@ -13,48 +13,18 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+import PlatformPeg from 'matrix-react-sdk/lib/PlatformPeg';
+
 var POKE_RATE_MS = 10 * 60 * 1000; // 10 min
-var currentVersion = null;
-var latestVersion = null;
-var listener = function(){}; // NOP
 
 module.exports = {
-    setVersionListener: function(fn) { // invoked with fn(currentVer, newVer)
-        listener = fn;
+    start: function() {
+        module.exports.poll();
+        setInterval(module.exports.poll, POKE_RATE_MS);
     },
 
-    run: function() {
-        var req = new XMLHttpRequest();
-        req.addEventListener("load", function() {
-            if (!req.responseText) {
-                return;
-            }
-            var ver = req.responseText.trim();
-            if (!currentVersion) {
-                currentVersion = ver;
-                listener(currentVersion, currentVersion);
-            }
-
-            if (ver !== latestVersion) {
-                latestVersion = ver;
-                if (module.exports.hasNewVersion()) {
-                    console.log("Current=%s Latest=%s", currentVersion, latestVersion);
-                    listener(currentVersion, latestVersion);
-                }
-            }
-        });
-        var cacheBuster = "?ts=" + new Date().getTime();
-        req.open("GET", "version" + cacheBuster);
-        req.send(); // can't suppress 404s from being logged.
-
-        setTimeout(module.exports.run, POKE_RATE_MS);
-    },
-
-    getCurrentVersion: function() {
-        return currentVersion;
-    },
-
-    hasNewVersion: function() {
-        return currentVersion && latestVersion && (currentVersion !== latestVersion);
+    poll: function() {
+        PlatformPeg.get().pollForUpdate();
     }
 };


### PR DESCRIPTION
 * Allow platforms to specify release notes
 * Make web update checking much, much simpler (ie. not manually using XMLHTTPRequest)