### PR TITLE
Add some CSS for  scalar error popup

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/views/rooms/RoomSettings.css
+++ b/src/skins/vector/css/matrix-react-sdk/views/rooms/RoomSettings.css
@@ -20,7 +20,9 @@ limitations under the License.
 }
 
 .mx_RoomSettings_leaveButton,
-.mx_RoomSettings_integrationsButton {
+.mx_RoomSettings_integrationsButton,
+.mx_RoomSettings_integrationsButton_error {
+    position: relative;
     height: 36px;
     background-color: #76cfa6;
     border-radius: 36px;
@@ -32,6 +34,21 @@ limitations under the License.
     cursor: pointer;
     padding-left: 12px;
     padding-right: 12px;
+}
+.mx_RoomSettings_integrationsButton_error {
+    pointer: not-allowed;
+}
+.mx_RoomSettings_integrationsButton_errorPopup {
+    position: absolute;
+    top: 110%;
+    left: -26%;
+    width: 150%;
+    padding: 2%;
+    font-size: 10pt;
+    line-height: 1.5em;
+    border-radius: 5px;
+    background-color: #000;
+    color: #fff;
 }
 
 .mx_RoomSettings_e2eIcon {


### PR DESCRIPTION
 The popup appears next to the `Manage Integrations` button if there was a problem contacting Scalar