### PR TITLE
Make auto-update configureable

### DIFF
--- a/electron/src/electron-main.js
+++ b/electron/src/electron-main.js
@@ -32,7 +32,6 @@ let vectorConfig = {};
 try {
     vectorConfig = require('../../vector/config.json');
 } catch (e) {
-    console.log(`file://${__dirname}/../../vector/config.json`, e);
     // it would be nice to check the error code here and bail if the config
     // is unparseable, but we get MODULE_NOT_FOUND in the case of a missing
     // file or invalid json, so node is just very unhelpful.


### PR DESCRIPTION
Otherwise everyone that builds electron vector will end up with
their apps auto-updatin to our version when we release an update.

Coming next: A way to manage our electron release process to make
sure we never ship a build with auto-update disabled.