### PR TITLE
Fix changelog dialog to  read new version format

### DIFF
--- a/src/components/views/dialogs/ChangelogDialog.js
+++ b/src/components/views/dialogs/ChangelogDialog.js
@@ -31,9 +31,10 @@ export default class ChangelogDialog extends React.Component {
         const version = this.props.newVersion.split('-');
         const version2 = this.props.version.split('-');
         if(version == null || version2 == null) return;
+        // parse versions of form: [vectorversion]-react-[react-sdk-version]-js-[js-sdk-version]
         for(let i=0; i<REPOS.length; i++) {
-            const oldVersion = version2[2*i+1];
-            const newVersion = version[2*i+1];
+            const oldVersion = version2[2*i];
+            const newVersion = version[2*i];
             request(`https://api.github.com/repos/${REPOS[i]}/compare/${oldVersion}...${newVersion}`, (a, b, body) => {
                 if(body == null) return;
                 this.setState({[REPOS[i]]: JSON.parse(body).commits});

--- a/src/components/views/globals/NewVersionBar.js
+++ b/src/components/views/globals/NewVersionBar.js
@@ -23,11 +23,11 @@ import PlatformPeg from 'matrix-react-sdk/lib/PlatformPeg';
 
 /**
  * Check a version string is compatible with the Changelog
- * dialog
+ * dialog ([vectorversion]-react-[react-sdk-version]-js-[js-sdk-version])
  */
 function checkVersion(ver) {
     const parts = ver.split('-');
-    return parts[0] == 'vector' && parts[2] == 'react' && parts[4] == 'js';
+    return parts.length == 5 && parts[1] == 'react' && parts[3] == 'js';
 }
 
 export default React.createClass({


### PR DESCRIPTION
Remove the 'vector' from the start of the version (otherwise the
tarballs are called vector-vector-[...].tar.gz). The jenkins
script already creates these files, so update accordingly.