### PR TITLE
Interface wording: Delete instead of Redact

### DIFF
--- a/src/components/views/context_menus/MessageContextMenu.js
+++ b/src/components/views/context_menus/MessageContextMenu.js
@@ -124,7 +124,7 @@ module.exports = React.createClass({
         if (!eventStatus) { // sent
             redactButton = (
                 <div className="mx_MessageContextMenu_field" onClick={this.onRedactClick}>
-                    Redact
+                    Delete
                 </div>
             );
         }

--- a/src/components/views/elements/ImageView.js
+++ b/src/components/views/elements/ImageView.js
@@ -150,7 +150,7 @@ module.exports = React.createClass({
         var eventRedact;
         if(showEventMeta) {
             eventRedact = (<div className="mx_ImageView_button" onClick={this.onRedactClick}>
-                Redact
+                Delete
             </div>);
         }
 


### PR DESCRIPTION
To delete a message "Redact" is too ambiguous . Most users translate "redact" with "edit" which is exactly not what it does.

"Delete" is unambiguous.

To make it sound more imaginative we could discuss "expunge" or "purge": http://dict.leo.org/ende/index_de.html#/search=l%C3%B6schen&searchLoc=0&resultOrder=basic&multiwordShowSingle=on&pos=0