### PR TITLE
Update to electron 1.4.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
   "build": {
     "appId": "im.riot.app",
     "category": "Network",
-    "electronVersion": "1.4.2",
+    "electronVersion": "1.4.8",
     "//asar=false": "https://github.com/electron-userland/electron-builder/issues/675",
     "asar": false,
     "dereference": true,


### PR DESCRIPTION
Which uses a new enough build of chromium that it accepts our SSL
certs.